### PR TITLE
fix(iOS): Remove hardcoded dark mode to enable light mode support

### DIFF
--- a/NetMonitor-iOS/Views/ContentView.swift
+++ b/NetMonitor-iOS/Views/ContentView.swift
@@ -75,7 +75,6 @@ struct ContentView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .tint(themeManager.accent)
         .accessibilityIdentifier("screen_main")
     }


### PR DESCRIPTION
## Summary

Removes the hardcoded  from iOS ContentView that was preventing light mode from working.

## Problem

The  had  hardcoded, which forced dark mode regardless of the user's appearance preference setting. This blocked iOS light mode support.

## Solution

Removed the hardcoded dark mode preference from ContentView. The  already correctly handles the user's appearance preference via  based on the  setting (light/dark/system).

## Related

- Fixes #140 (iOS portion - Mac was already fixed in PR #147)

## Testing

- Build passes locally
- Theme.swift already has full light/dark adaptive colors