### PR TITLE
fix: create build/ directory before writing complexity report

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -136,6 +136,7 @@ jobs:
 
       - name: Generate complexity report
         run: |
+          mkdir -p build
           echo "## Cyclomatic Complexity Report" > build/complexity-report.md
           echo "" >> build/complexity-report.md
           echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> build/complexity-report.md


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/jbcrane13/NetMonitor-2.0/sessions/67bb4761-ea4d-46b9-aaed-b088eda7c51d

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
