### PR TITLE
fix: apply main's correct versions of RateAppService and Observabilit…

### DIFF
--- a/NetMonitor-iOS/Platform/RateAppService.swift
+++ b/NetMonitor-iOS/Platform/RateAppService.swift
@@ -8,7 +8,7 @@ enum RateAppService {
 
     // MARK: - App Store ID
 
-    // TODO: Update with real App Store ID once live
+    /// Replace with the real App Store ID before shipping.
     static let appStoreID: String = "APP_STORE_ID_PLACEHOLDER"
     private static let reviewURL = "itms-apps://itunes.apple.com/app/id\(appStoreID)?action=write-review"
     private static let ratingsURL = "itms-apps://itunes.apple.com/app/id\(appStoreID)"

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ObservabilityService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ObservabilityService.swift
@@ -21,7 +21,9 @@ public final class ObservabilityService: @unchecked Sendable {
 
     private let logger = Logger(subsystem: "com.netmonitor", category: "Observability")
     private let state = OSAllocatedUnfairLock(initialState: State())
-    private(set) var isInitialized: Bool { state.withLock { $0.isInitialized } }
+    var isInitialized: Bool {
+        state.withLock { $0.isInitialized }
+    }
 
     private init() {}
 


### PR DESCRIPTION
…yService

Agent-Logs-Url: https://github.com/jbcrane13/NetMonitor-2.0/sessions/430082fa-b9f6-4d6f-bd2d-aea79f994450

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
