### PR TITLE
fix: add ZIPFoundation dependency for BlueprintSaveLoadManager

### DIFF
--- a/NetMonitor-2.0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NetMonitor-2.0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d574d780020721741e91d4824f3316bb819be43cd01313bab7844f762b95fe21",
+  "originHash" : "cd6140095199df5c48301163764be1c501cf89572f274cc7ecf2be71a0b10a65",
   "pins" : [
     {
       "identity" : "sentry-cocoa",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "16cd512711375fa73f25ae5e373f596bdf4251ae",
         "version" : "8.58.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/Packages/NetMonitorCore/Package.swift
+++ b/Packages/NetMonitorCore/Package.swift
@@ -15,14 +15,16 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../NetworkScanKit"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.49.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.49.0"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.0")
     ],
     targets: [
         .target(
             name: "NetMonitorCore",
             dependencies: [
                 "NetworkScanKit",
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: "Sentry", package: "sentry-cocoa"),
+                .product(name: "ZIPFoundation", package: "ZIPFoundation")
             ],
             path: "Sources/NetMonitorCore",
             swiftSettings: [

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/BlueprintSaveLoadManager.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/BlueprintSaveLoadManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ZIPFoundation
 
 // MARK: - BlueprintFileError
 


### PR DESCRIPTION
## Summary
- Added ZIPFoundation package dependency to NetMonitorCore
- Added `import ZIPFoundation` to BlueprintSaveLoadManager.swift
- Fixes build error introduced in PR #143

## Problem
PR #143 added `FileManager.zipItem`/`unzipItem` calls for blueprint ZIP export, but these methods come from the ZIPFoundation library, not Foundation framework. This caused build failures:
```
error: value of type 'FileManager' has no member 'zipItem'
error: value of type 'FileManager' has no member 'unzipItem'
```

## Solution
Added ZIPFoundation as a package dependency in NetMonitorCore's Package.swift and imported it in BlueprintSaveLoadManager.swift.

This fix unblocks all NetMonitor development which has been broken since the merge of PR #143.