### PR TITLE
fix: make IOSUITestCase setUp async throws for XCTest concurrency

### DIFF
--- a/Tests/NetMonitor-iOSUITests/IOSUITestCase.swift
+++ b/Tests/NetMonitor-iOSUITests/IOSUITestCase.swift
@@ -4,12 +4,12 @@ import XCTest
 class IOSUITestCase: XCTestCase {
     var app: XCUIApplication!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         app = XCUIApplication()
         addUIInterruptionMonitor(withDescription: "System Alerts") { alert in
             let preferredButtons = [
-                "Don’t Allow", "Don't Allow", "Not Now", "Cancel", "OK", "Allow While Using App", "Allow"
+                "Don't Allow", "Don't Allow", "Not Now", "Cancel", "OK", "Allow While Using App", "Allow"
             ]
 
             for title in preferredButtons {
@@ -34,7 +34,8 @@ class IOSUITestCase: XCTestCase {
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10), "App should launch to foreground")
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
+        try await super.tearDown()
         app = nil
     }
 

--- a/Tests/NetMonitor-iOSUITests/NetworkMapUITests.swift
+++ b/Tests/NetMonitor-iOSUITests/NetworkMapUITests.swift
@@ -3,8 +3,8 @@ import XCTest
 @MainActor
 final class NetworkMapUITests: IOSUITestCase {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
         app.tabBars.buttons["Map"].tap()
     }
 


### PR DESCRIPTION
## Summary

Fixes #157 - TestRunner crash in WebBrowserToolUITests

## Root Cause

WebBrowserToolUITests.setUp() was async throws and called super.setUp(), but the parent class IOSUITestCase used setUpWithError() (synchronous). The async setUp() never calls setUpWithError() in XCTest's inheritance chain, so the app was never launched.

When the test tried to call openWebBrowser(), the app was nil, causing an assertion failure.

## Changes

1. **IOSUITestCase.swift**: 
   - Changed `setUpWithError()` to `setUp() async throws`
   - Changed `tearDownWithError()` to `tearDown() async throws`
   
2. **NetworkMapUITests.swift**:
   - Updated `setUpWithError()` to `setUp() async throws` to match parent

## Testing

- WebBrowserToolUITests should now properly launch the app before running tests
- NetworkMapUITests will continue to work with the async parent method