### PR TITLE
fix(macOS): replace hardcoded dark mode colors with adaptive theme colors

### DIFF
--- a/NetMonitor-macOS/Utilities/MacTheme.swift
+++ b/NetMonitor-macOS/Utilities/MacTheme.swift
@@ -151,6 +151,33 @@ enum MacTheme {
             light: .black.withAlphaComponent(0.02)
         ))
 
+        /// Dark-mode equivalent of `black.opacity(0.15)` — preserves the original dark styling
+        /// while providing an appropriate tint in light mode.
+        static let subtleBackgroundMedium = Color(nsColor: macColor(
+            dark: .black.withAlphaComponent(0.15),
+            light: .black.withAlphaComponent(0.03)
+        ))
+
+        // MARK: — Sidebar overlay tokens (adaptive)
+
+        /// Unselected profile-pill fill. Dark: `white.opacity(0.05)` — matches original sidebar look.
+        static let sidebarPillBackground = Color(nsColor: macColor(
+            dark: .white.withAlphaComponent(0.05),
+            light: .black.withAlphaComponent(0.04)
+        ))
+
+        /// Unselected profile-pill / row border. Dark: `white.opacity(0.10)` — matches original stroke weight.
+        static let subtleBorder = Color(nsColor: macColor(
+            dark: .white.withAlphaComponent(0.10),
+            light: .black.withAlphaComponent(0.05)
+        ))
+
+        /// Device-count badge fill in sidebar rows. Dark: `white.opacity(0.07)` — matches original look.
+        static let sidebarBadgeBackground = Color(nsColor: macColor(
+            dark: .white.withAlphaComponent(0.07),
+            light: .black.withAlphaComponent(0.04)
+        ))
+
         // MARK: — Sidebar (adaptive)
 
         static let sidebarActive = Color(nsColor: macColor(

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -120,7 +120,7 @@ struct ProfilePill: View {
                     Circle()
                         .fill(MacTheme.Colors.success)
                         .frame(width: 8, height: 8)
-                        .overlay(Circle().stroke(MacTheme.Colors.crystalBorder, lineWidth: 1.5))
+                        .overlay(Circle().stroke(Color.primary, lineWidth: 1.5))
                         .offset(x: 18, y: -18)
                 }
             }

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -105,11 +105,11 @@ struct ProfilePill: View {
         VStack(spacing: 4) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(isSelected ? MacTheme.Colors.sidebarActive : MacTheme.Colors.subtleBackground)
+                    .fill(isSelected ? MacTheme.Colors.sidebarActive : MacTheme.Colors.sidebarPillBackground)
                     .frame(width: 44, height: 44)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isSelected ? accentColor : MacTheme.Colors.crystalBorder, lineWidth: 1)
+                            .stroke(isSelected ? accentColor : MacTheme.Colors.subtleBorder, lineWidth: 1)
                     )
 
                 Image(systemName: profile.connectionType.iconName)
@@ -174,7 +174,7 @@ struct SidebarRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 5)
                     .padding(.vertical, 2)
-                    .background(MacTheme.Colors.subtleBackground, in: RoundedRectangle(cornerRadius: 4))
+                    .background(MacTheme.Colors.sidebarBadgeBackground, in: RoundedRectangle(cornerRadius: 4))
             }
 
             // Main badge (ACTIVE, status counts, etc.)

--- a/NetMonitor-macOS/Views/Tools/GeoTraceView.swift
+++ b/NetMonitor-macOS/Views/Tools/GeoTraceView.swift
@@ -5,6 +5,7 @@ import NetMonitorCore
 
 /// macOS GeoTrace — visual traceroute on a world map.
 struct GeoTraceView: View {
+    @Environment(\.colorScheme) private var colorScheme
     @State private var host = ""
     @State private var isRunning = false
     @State private var hops: [GeoTraceHop] = []
@@ -86,6 +87,10 @@ struct GeoTraceView: View {
         }
     }
 
+    private var hopAnnotationOutlineColor: Color {
+        colorScheme == .dark ? .white : .black.opacity(0.75)
+    }
+
     private func macHopAnnotation(_ hop: GeoTraceHop) -> some View {
         ZStack {
             Circle()
@@ -94,7 +99,7 @@ struct GeoTraceView: View {
             Circle()
                 .fill(hop.latencyColor)
                 .frame(width: selectedHop?.id == hop.id ? 14 : 10)
-                .overlay(Circle().stroke(MacTheme.Colors.crystalBorder, lineWidth: 1.5))
+                .overlay(Circle().stroke(hopAnnotationOutlineColor, lineWidth: 1.5))
         }
         .animation(.easeInOut(duration: 0.15), value: selectedHop?.id == hop.id)
     }

--- a/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
+++ b/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
@@ -110,7 +110,7 @@ struct SSLCertificateMonitorView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
         }
-        .background(MacTheme.Colors.subtleBackground)
+        .background(MacTheme.Colors.subtleBackgroundMedium)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Fixes #160 - Replaces hardcoded dark-mode-only colors with adaptive MacTheme colors that properly support both light and dark mode.

## Changes

- **SidebarView**: Fixed sidebar backgrounds, borders, and status indicator colors
- **DeviceDetailView**: Fixed action button text color  
- **Tool Views**: Fixed background colors in DNSLookupTool, BonjourBrowserTool, SpeedTestTool, PingToolView, SubnetCalculatorTool, TracerouteTool, PortScannerTool, SSLCertificateMonitor

## Technical Details

Replaced:
- `Color.white.opacity(0.05)` → `MacTheme.Colors.subtleBackground`
- `Color.white.opacity(0.07)` → `MacTheme.Colors.subtleBackground`
- `Color.white.opacity(0.1)` → `MacTheme.Colors.crystalBorder`
- `Color.black.opacity(0.1)` → `MacTheme.Colors.subtleBackgroundLight`
- `Color.black.opacity(0.15)` → `MacTheme.Colors.subtleBackground`
- `Color.black.opacity(0.2)` → `MacTheme.Colors.subtleBackground`
- `Color.white` (stroke) → `MacTheme.Colors.crystalBorder`

All colors now use MacTheme's adaptive NSColor wrapper that reads the current appearance and returns appropriate dark/light values.