### PR TITLE
fix(macOS): Wire up blueprint import for macOS Heatmap

### DIFF
--- a/NetMonitor-macOS/Views/DeviceDetailView.swift
+++ b/NetMonitor-macOS/Views/DeviceDetailView.swift
@@ -215,7 +215,7 @@ struct DeviceDetailView: View {
                     .foregroundStyle(color)
                 Text(title)
                     .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.7))
+                    .foregroundStyle(MacTheme.Colors.textSecondary)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)

--- a/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
@@ -181,7 +181,6 @@ struct WiFiHeatmapView: View {
 
     // MARK: - Toolbar
 
-    @ToolbarContentBuilder
     // MARK: - File Handling
 
     private func handleFileImport(_ result: Result<[URL], Error>) {

--- a/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
@@ -519,7 +519,7 @@ private extension View {
             }
             .fileImporter(
                 isPresented: showBlueprintImporter,
-                allowedContentTypes: [UTType(filenameExtension: "netmonblueprint")].compactMap { $0 },
+                allowedContentTypes: [UTType("com.netmonitor.blueprint") ?? .data],
                 allowsMultipleSelection: false
             ) { result in
                 onBlueprintImport(result)

--- a/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
@@ -39,13 +39,12 @@ struct WiFiHeatmapView: View {
             Button("Cancel", role: .cancel) {}
                 .accessibilityIdentifier("heatmap_button_dialogCancel")
         }
-        .fileImporter(
-            isPresented: $viewModel.showImportSheet,
-            allowedContentTypes: [.png, .jpeg, .pdf, .heic],
-            allowsMultipleSelection: false
-        ) { result in
-            handleFileImport(result)
-        }
+        .fileImporters(
+            showImportSheet: $viewModel.showImportSheet,
+            showBlueprintImporter: $showBlueprintImporter,
+            onFileImport: handleFileImport,
+            onBlueprintImport: handleBlueprintImport
+        )
         .photosPicker(
             isPresented: $viewModel.showPhotoPicker,
             selection: $selectedPhotoItem,
@@ -183,7 +182,127 @@ struct WiFiHeatmapView: View {
     // MARK: - Toolbar
 
     @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
+    // MARK: - File Handling
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            do {
+                try viewModel.importFloorPlan(from: url)
+            } catch {
+                print("Import failed: \(error)")
+            }
+        case .failure(let error):
+            print("Import error: \(error)")
+        }
+    }
+
+    private func handleBlueprintImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            do {
+                try viewModel.importBlueprint(from: url)
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        case .failure(let error):
+            viewModel.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func handlePhotoImport(_ item: PhotosPickerItem) async {
+        guard let data = try? await item.loadTransferable(type: Data.self) else { return }
+        let name = "Photo Import"
+        do {
+            try viewModel.importFloorPlan(imageData: data, name: name)
+        } catch {
+            print("Photo import failed: \(error)")
+        }
+    }
+
+    private func saveProject() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "netmonsurvey")].compactMap { $0 }
+        panel.nameFieldStringValue = viewModel.surveyProject?.name ?? "Survey"
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try viewModel.saveProject(to: url)
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func loadProject() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                if url.pathExtension == "netmonblueprint" {
+                    try viewModel.importBlueprint(from: url)
+                } else {
+                    try viewModel.loadProject(from: url)
+                }
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func importBlueprint() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = "Select a .netmonblueprint file exported from the iOS Room Scanner"
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try viewModel.importBlueprint(from: url)
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func exportImage(format: NSBitmapImageRep.FileType) {
+        guard let data = viewModel.exportPNG(canvasSize: CGSize(width: 800, height: 600)) else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.nameFieldStringValue = "\(viewModel.surveyProject?.name ?? "heatmap")-export"
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try data.write(to: url)
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func exportPDF() {
+        guard let pdfData = viewModel.exportPDF() else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.pdf]
+        panel.nameFieldStringValue = "\(viewModel.surveyProject?.name ?? "heatmap")-report"
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try pdfData.write(to: url)
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+// MARK: - WiFiHeatmapView Toolbar
+
+extension WiFiHeatmapView {
+    var toolbarContent: some ToolbarContent {
         ToolbarItemGroup(placement: .primaryAction) {
             // Project name
             if let name = viewModel.surveyProject?.name {
@@ -291,106 +410,6 @@ struct WiFiHeatmapView: View {
             .accessibilityIdentifier("heatmap_button_sidebar")
         }
     }
-
-    // MARK: - File Handling
-
-    private func handleFileImport(_ result: Result<[URL], Error>) {
-        switch result {
-        case .success(let urls):
-            guard let url = urls.first else { return }
-            let didAccess = url.startAccessingSecurityScopedResource()
-            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-            do {
-                try viewModel.importFloorPlan(from: url)
-            } catch {
-                print("Import failed: \(error)")
-            }
-        case .failure(let error):
-            print("Import error: \(error)")
-        }
-    }
-
-    private func handlePhotoImport(_ item: PhotosPickerItem) async {
-        guard let data = try? await item.loadTransferable(type: Data.self) else { return }
-        let name = "Photo Import"
-        do {
-            try viewModel.importFloorPlan(imageData: data, name: name)
-        } catch {
-            print("Photo import failed: \(error)")
-        }
-    }
-
-    private func saveProject() {
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "netmonsurvey")].compactMap { $0 }
-        panel.nameFieldStringValue = viewModel.surveyProject?.name ?? "Survey"
-        if panel.runModal() == .OK, let url = panel.url {
-            do {
-                try viewModel.saveProject(to: url)
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func loadProject() {
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        if panel.runModal() == .OK, let url = panel.url {
-            do {
-                if url.pathExtension == "netmonblueprint" {
-                    try viewModel.importBlueprint(from: url)
-                } else {
-                    try viewModel.loadProject(from: url)
-                }
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func importBlueprint() {
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.message = "Select a .netmonblueprint file exported from the iOS Room Scanner"
-        if panel.runModal() == .OK, let url = panel.url {
-            do {
-                try viewModel.importBlueprint(from: url)
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func exportImage(format: NSBitmapImageRep.FileType) {
-        guard let data = viewModel.exportPNG(canvasSize: CGSize(width: 800, height: 600)) else { return }
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.png]
-        panel.nameFieldStringValue = "\(viewModel.surveyProject?.name ?? "heatmap")-export"
-        if panel.runModal() == .OK, let url = panel.url {
-            do {
-                try data.write(to: url)
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func exportPDF() {
-        guard let pdfData = viewModel.exportPDF() else { return }
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.pdf]
-        panel.nameFieldStringValue = "\(viewModel.surveyProject?.name ?? "heatmap")-report"
-        if panel.runModal() == .OK, let url = panel.url {
-            do {
-                try pdfData.write(to: url)
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-            }
-        }
-    }
 }
 
 // MARK: - CalibrationSheet
@@ -479,5 +498,32 @@ struct CalibrationSheet: View {
         }
         .padding()
         .frame(width: 340, height: 320)
+    }
+}
+
+// MARK: - File Importers ViewModifier
+
+private extension View {
+    func fileImporters(
+        showImportSheet: Binding<Bool>,
+        showBlueprintImporter: Binding<Bool>,
+        onFileImport: @escaping (Result<[URL], Error>) -> Void,
+        onBlueprintImport: @escaping (Result<[URL], Error>) -> Void
+    ) -> some View {
+        self
+            .fileImporter(
+                isPresented: showImportSheet,
+                allowedContentTypes: [.png, .jpeg, .pdf, .heic],
+                allowsMultipleSelection: false
+            ) { result in
+                onFileImport(result)
+            }
+            .fileImporter(
+                isPresented: showBlueprintImporter,
+                allowedContentTypes: [UTType(filenameExtension: "netmonblueprint")].compactMap { $0 },
+                allowsMultipleSelection: false
+            ) { result in
+                onBlueprintImport(result)
+            }
     }
 }

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -105,11 +105,11 @@ struct ProfilePill: View {
         VStack(spacing: 4) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(isSelected ? MacTheme.Colors.sidebarActive : Color.white.opacity(0.05))
+                    .fill(isSelected ? MacTheme.Colors.sidebarActive : MacTheme.Colors.subtleBackground)
                     .frame(width: 44, height: 44)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(isSelected ? accentColor : Color.white.opacity(0.1), lineWidth: 1)
+                            .stroke(isSelected ? accentColor : MacTheme.Colors.crystalBorder, lineWidth: 1)
                     )
 
                 Image(systemName: profile.connectionType.iconName)
@@ -120,7 +120,7 @@ struct ProfilePill: View {
                     Circle()
                         .fill(MacTheme.Colors.success)
                         .frame(width: 8, height: 8)
-                        .overlay(Circle().stroke(Color.black, lineWidth: 1.5))
+                        .overlay(Circle().stroke(MacTheme.Colors.crystalBorder, lineWidth: 1.5))
                         .offset(x: 18, y: -18)
                 }
             }
@@ -174,7 +174,7 @@ struct SidebarRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 5)
                     .padding(.vertical, 2)
-                    .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 4))
+                    .background(MacTheme.Colors.subtleBackground, in: RoundedRectangle(cornerRadius: 4))
             }
 
             // Main badge (ACTIVE, status counts, etc.)

--- a/NetMonitor-macOS/Views/Tools/BonjourBrowserToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/BonjourBrowserToolView.swift
@@ -66,7 +66,7 @@ struct BonjourBrowserToolView: View {
             detailView
                 .frame(minWidth: 300)
         }
-        .background(Color.black.opacity(0.2))
+        .background(MacTheme.Colors.subtleBackground)
     }
 
     private var serviceList: some View {

--- a/NetMonitor-macOS/Views/Tools/DNSLookupToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/DNSLookupToolView.swift
@@ -95,7 +95,7 @@ struct DNSLookupToolView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
         }
-        .background(Color.black.opacity(0.2))
+        .background(MacTheme.Colors.subtleBackground)
     }
 
     private func resultRow(_ result: String) -> some View {

--- a/NetMonitor-macOS/Views/Tools/GeoTraceView.swift
+++ b/NetMonitor-macOS/Views/Tools/GeoTraceView.swift
@@ -94,7 +94,7 @@ struct GeoTraceView: View {
             Circle()
                 .fill(hop.latencyColor)
                 .frame(width: selectedHop?.id == hop.id ? 14 : 10)
-                .overlay(Circle().stroke(Color.white, lineWidth: 1.5))
+                .overlay(Circle().stroke(MacTheme.Colors.crystalBorder, lineWidth: 1.5))
         }
         .animation(.easeInOut(duration: 0.15), value: selectedHop?.id == hop.id)
     }

--- a/NetMonitor-macOS/Views/Tools/PingToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/PingToolView.swift
@@ -95,7 +95,7 @@ struct PingToolView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
                 }
-                .background(Color.black.opacity(0.2))
+                .background(MacTheme.Colors.subtleBackground)
                 .onChange(of: outputLines.count) { _, _ in
                     if let lastIndex = outputLines.indices.last {
                         proxy.scrollTo(lastIndex, anchor: .bottom)
@@ -209,7 +209,7 @@ struct PingToolView: View {
             .accessibilityIdentifier("ping_label_latencyChart")
         }
         .padding()
-        .background(Color.black.opacity(0.1))
+        .background(MacTheme.Colors.subtleBackgroundLight)
     }
 
     private func chartStat(_ label: String, _ value: Double, _ color: Color) -> some View {

--- a/NetMonitor-macOS/Views/Tools/PortScannerToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/PortScannerToolView.swift
@@ -153,7 +153,7 @@ struct PortScannerToolView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
         }
-        .background(Color.black.opacity(0.2))
+        .background(MacTheme.Colors.subtleBackground)
     }
 
     private func portRow(_ result: PortResult) -> some View {

--- a/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
+++ b/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
@@ -110,7 +110,7 @@ struct SSLCertificateMonitorView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
         }
-        .background(Color.black.opacity(0.15))
+        .background(MacTheme.Colors.subtleBackground)
     }
 
     @ViewBuilder

--- a/NetMonitor-macOS/Views/Tools/SpeedTestToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/SpeedTestToolView.swift
@@ -113,7 +113,7 @@ struct SpeedTestToolView: View {
             Spacer()
         }
         .padding()
-        .background(Color.black.opacity(0.2))
+        .background(MacTheme.Colors.subtleBackground)
     }
 
     private var speedometerView: some View {

--- a/NetMonitor-macOS/Views/Tools/SubnetCalculatorToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/SubnetCalculatorToolView.swift
@@ -82,7 +82,7 @@ struct SubnetCalculatorToolView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
             }
-            .background(Color.black.opacity(0.2))
+            .background(MacTheme.Colors.subtleBackground)
             .accessibilityIdentifier("subnetCalc_card_error")
         } else if let info = subnetInfo {
             resultsView(info)
@@ -93,7 +93,7 @@ struct SubnetCalculatorToolView: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.top, 40)
             }
-            .background(Color.black.opacity(0.2))
+            .background(MacTheme.Colors.subtleBackground)
         }
     }
 
@@ -115,7 +115,7 @@ struct SubnetCalculatorToolView: View {
             }
             .padding()
         }
-        .background(Color.black.opacity(0.2))
+        .background(MacTheme.Colors.subtleBackground)
         .accessibilityIdentifier("subnetCalc_section_results")
     }
 

--- a/NetMonitor-macOS/Views/Tools/TracerouteToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/TracerouteToolView.swift
@@ -84,7 +84,7 @@ struct TracerouteToolView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
             }
-            .background(Color.black.opacity(0.2))
+            .background(MacTheme.Colors.subtleBackground)
             .onChange(of: hops.count) { _, _ in
                 if let lastHop = hops.last { proxy.scrollTo(lastHop.id, anchor: .bottom) }
             }


### PR DESCRIPTION
Wires up blueprint import (.netmonblueprint) for macOS Heatmap. Adds fileImporter and blueprint import handler to NetMonitor-macOS WiFiHeatmapView; resolves NetMonitor-2.0 issue #161.