### PR TITLE
test: v2.1 regression guards + 2 silent bug fixes

### DIFF
--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		70926F040D08693ACF1B16B9 /* RateAppService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41299411CDDE99A5C409A044 /* RateAppService.swift */; };
 		70B6BCE0269CC96E02CC719D /* MonitoringSessionSaveErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EADE9676FF124E9D257FBC /* MonitoringSessionSaveErrorTests.swift */; };
 		718A60353148EC26CB8F6118 /* DataExportServiceErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F0E93710611FD1D17F8CD5 /* DataExportServiceErrorTests.swift */; };
+		72542CEA548526C8566483DA /* AppearanceModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA99B879D32BE1A79C557AA6 /* AppearanceModeTests.swift */; };
 		729D787511EEF4842026B42F /* WorldPingToolViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1DA22FDAA0AE45CB063132 /* WorldPingToolViewModel.swift */; };
 		72E137FE98FFCEB9477A7085 /* DashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D7904358AD4EFE10410C4C /* DashboardViewModelTests.swift */; };
 		737BD05750E732CBAB510C7C /* DeviceCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9283B241BBF265DC019B4B /* DeviceCardView.swift */; };
@@ -256,6 +257,7 @@
 		9462D6AE8EBCC169F9F86831 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0A10C8D0A4922F6690C62B /* StatusBadge.swift */; };
 		94736D3A87E0BEFA4670767F /* PDFReportGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603D57D4202F475E3E7CB108 /* PDFReportGenerator.swift */; };
 		958AFBDAE2D16F8A52DE6159 /* NetworkHealthScoreViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309899FF956ACA75843E0CC9 /* NetworkHealthScoreViewModelTests.swift */; };
+		9677AA628490B48410734FD8 /* WiFiHeatmapViewModelSaveLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B4635DD799E78E2C32767D /* WiFiHeatmapViewModelSaveLoadTests.swift */; };
 		97A541C0E4E20292292AD328 /* ICMPMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A980FAAF1EB5E1BBEF24816A /* ICMPMonitorServiceTests.swift */; };
 		99C5EDA2716DD0A167CDA299 /* GeoFenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEDB32CF47D675F61CF5563 /* GeoFenceManager.swift */; };
 		99ED6C915DDE983BA1149E20 /* InteractionFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152C60E77B4F26FE190B6091 /* InteractionFlowUITests.swift */; };
@@ -717,6 +719,7 @@
 		A662524F3B46C11AB6583962 /* ARWiFiSignalUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARWiFiSignalUITests.swift; sourceTree = "<group>"; };
 		A7191F3156FFC451BBDAA904 /* DefaultTargetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTargetsProvider.swift; sourceTree = "<group>"; };
 		A76DD42C0ACB3B6EC149A66C /* WiFiHeatmapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModel.swift; sourceTree = "<group>"; };
+		A8B4635DD799E78E2C32767D /* WiFiHeatmapViewModelSaveLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModelSaveLoadTests.swift; sourceTree = "<group>"; };
 		A980FAAF1EB5E1BBEF24816A /* ICMPMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICMPMonitorServiceTests.swift; sourceTree = "<group>"; };
 		AAE65435D045DE3913F261E2 /* MacConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacConnectionServiceTests.swift; sourceTree = "<group>"; };
 		ABFB99B16D29E2338B306CA9 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -738,6 +741,7 @@
 		B6DBA0C16A1DE7F77F218E6A /* WHOISToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHOISToolUITests.swift; sourceTree = "<group>"; };
 		B8D54CA3F23F80DECD04EB0F /* ScheduledScanUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledScanUITests.swift; sourceTree = "<group>"; };
 		B95AD20B5D8E360138D27BC7 /* NewFeatureUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureUnitTests.swift; sourceTree = "<group>"; };
+		BA99B879D32BE1A79C557AA6 /* AppearanceModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceModeTests.swift; sourceTree = "<group>"; };
 		BAC76B1286C767294ED03042 /* ISPCardViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPCardViewModelExtendedTests.swift; sourceTree = "<group>"; };
 		BC50DF5BC553FC2B2E1E51FA /* ISPLookupServiceCacheErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceCacheErrorTests.swift; sourceTree = "<group>"; };
 		BC9B8228A5B2FFCD294C88EC /* ToolsGoldenPathUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsGoldenPathUITests.swift; sourceTree = "<group>"; };
@@ -1527,6 +1531,7 @@
 		EB8CAB1CD898FE75D7DED009 /* NetMonitor-macOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				BA99B879D32BE1A79C557AA6 /* AppearanceModeTests.swift */,
 				7D45B35B4F0CDECD456347FB /* ARPScannerServiceTests.swift */,
 				ED714BFBF69259A62EF490EA /* BandwidthMonitorServiceTests.swift */,
 				902E1E2A42E01B90226266F6 /* CompanionMessageContractTests.swift */,
@@ -1577,6 +1582,7 @@
 				7FEBEA87C402A3FB6AB1C6C5 /* WakeOnLanActionTests.swift */,
 				E56046F3C1668E68228A5411 /* WiFiHeatmapViewModelBlueprintTests.swift */,
 				66EEF66329B8A2875D465BDB /* WiFiHeatmapViewModelExportTests.swift */,
+				A8B4635DD799E78E2C32767D /* WiFiHeatmapViewModelSaveLoadTests.swift */,
 				096A6527A650F8CB69177B9D /* WiFiHeatmapViewModelTests.swift */,
 				7937C6318E83D9BD57EF3ACD /* WorldPingServiceErrorSurfacingTests.swift */,
 				FB80047F0EAF4F9DE0C0E360 /* WorldPingServiceIntegrationTests.swift */,
@@ -2173,6 +2179,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08ECB7BB30EF93F6BBD50079 /* ARPScannerServiceTests.swift in Sources */,
+				72542CEA548526C8566483DA /* AppearanceModeTests.swift in Sources */,
 				8DEBD7188452657834F7EFFF /* BandwidthMonitorServiceTests.swift in Sources */,
 				FCC5D14634F9297C431DD2F7 /* CompanionMessageContractTests.swift in Sources */,
 				2490EF6A85B3B4EFE90C049F /* CompanionMessageHandlerExtendedTests.swift in Sources */,
@@ -2223,6 +2230,7 @@
 				6BAD6EDD7B3B66636B4FB6CA /* WakeOnLanActionTests.swift in Sources */,
 				F0DA93D232132A64FE567152 /* WiFiHeatmapViewModelBlueprintTests.swift in Sources */,
 				DE52B8ABF0A9D8D6390D3456 /* WiFiHeatmapViewModelExportTests.swift in Sources */,
+				9677AA628490B48410734FD8 /* WiFiHeatmapViewModelSaveLoadTests.swift in Sources */,
 				75EEA8D02BD5B269F3D92AAE /* WiFiHeatmapViewModelTests.swift in Sources */,
 				FCE225274D7B93E9D455C134 /* WorldPingServiceErrorSurfacingTests.swift in Sources */,
 				597896FAD4C7E007E5C46CFD /* WorldPingServiceIntegrationTests.swift in Sources */,

--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		7D9483D8831B8A58460A4154 /* SSLCertificateMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FAEC1E8F7808AA442A59FE /* SSLCertificateMonitorView.swift */; };
 		7F00E64730D8740119EE9A10 /* NetworkHealthScoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF03EF568E16FEB77A94E7B /* NetworkHealthScoreServiceTests.swift */; };
 		7F687E2AC8DF228885E5FCE3 /* NetMonitor_macOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED30F91ABCADD39A629C18A /* NetMonitor_macOSTests.swift */; };
+		7F93CBEDC7BCC5DEDCC39438 /* RoomPlanTaskTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD8579297FEBA5BB52B05F5 /* RoomPlanTaskTimeoutTests.swift */; };
 		817E1E1561D2AD55E5836DAC /* MacGlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E42E03E6C5BFDF617454119 /* MacGlassCard.swift */; };
 		81A7E24923789CEB591B26C2 /* SpeedTestToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824214C53D0723B326A18CEF /* SpeedTestToolView.swift */; };
 		8231D5C1C5D84A46D733F959 /* HeatmapSurveyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF3108C4649D9983D9F89C0 /* HeatmapSurveyViewModelTests.swift */; };
@@ -249,6 +250,7 @@
 		910D3D44366C735C9602B17E /* NetworkScanKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0F47FE6FA4E6294CF46C936 /* NetworkScanKit */; };
 		917220E28C0956215C93CDD0 /* DataExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A0A2582C0B7312FA42748E /* DataExportService.swift */; };
 		91E8395EA4E41C1E53A80061 /* NetworkHealthScoreViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3B7AE861BC947A81FBCFD0 /* NetworkHealthScoreViewModelTests.swift */; };
+		926C48FA20F04F3FCB81A854 /* ShortcutsWiFiProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60F86180BBDA5E9C2473370 /* ShortcutsWiFiProviderTests.swift */; };
 		9286881359E30828C4237AE9 /* ISPCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B3599D2C2AFE8A2006E258 /* ISPCardViewModelTests.swift */; };
 		92D79310FF0B4D2577E541FA /* DeviceDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC804A214B32FE44709510C9 /* DeviceDetailViewModelTests.swift */; };
 		9462D6AE8EBCC169F9F86831 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0A10C8D0A4922F6690C62B /* StatusBadge.swift */; };
@@ -494,6 +496,7 @@
 		1BFA32A2D8AD16EEFF35C181 /* NetMonitor-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "NetMonitor-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C164B5AC392FB3AC879093A /* VPNInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoViewModel.swift; sourceTree = "<group>"; };
 		1CA8D556A3CF18E6815DD8AC /* DeviceDiscoveryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDiscoveryCoordinator.swift; sourceTree = "<group>"; };
+		1DD8579297FEBA5BB52B05F5 /* RoomPlanTaskTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPlanTaskTimeoutTests.swift; sourceTree = "<group>"; };
 		1E3F3A93C15C01F45D8E37D2 /* ICMPMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICMPMonitorService.swift; sourceTree = "<group>"; };
 		1E4BCAE06DD86235A4D27BA1 /* SharedServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedServices.swift; sourceTree = "<group>"; };
 		1EB3E1D27CA2099DD420EEAE /* LatencyAnalysisCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyAnalysisCard.swift; sourceTree = "<group>"; };
@@ -838,6 +841,7 @@
 		F566B193A0894428EF6E3382 /* EventListenerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventListenerServiceTests.swift; sourceTree = "<group>"; };
 		F5A0A2582C0B7312FA42748E /* DataExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExportService.swift; sourceTree = "<group>"; };
 		F5FB4FB0D3D64F7724CB521D /* PublicIPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicIPService.swift; sourceTree = "<group>"; };
+		F60F86180BBDA5E9C2473370 /* ShortcutsWiFiProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsWiFiProviderTests.swift; sourceTree = "<group>"; };
 		F6D260F565079AC63677DCB7 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		F84B2379791919EAF70CBFB5 /* MacOSToolOutcomeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSToolOutcomeUITests.swift; sourceTree = "<group>"; };
 		F9745FD9482D4F193CBA93FE /* TracerouteToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerouteToolViewModel.swift; sourceTree = "<group>"; };
@@ -1239,12 +1243,14 @@
 				DC30204FAADF62E903865979 /* PublicIPServiceTests.swift */,
 				32E3D72DC25778944A2085E6 /* RateAppServiceTests.swift */,
 				8393BFDDAF199B582E13D567 /* RoomPlanScannerViewModelTests.swift */,
+				1DD8579297FEBA5BB52B05F5 /* RoomPlanTaskTimeoutTests.swift */,
 				B0BED56FCE2CE5CDD9B8A403 /* SaveWiFiReadingIntentTests.swift */,
 				4C154BB6B6A5747AA89E1F0E /* ScanThermalManagerTests.swift */,
 				7FE55D064CFB3CE51457346A /* ScheduledScanViewModelTests.swift */,
 				5F792E6868E8E959ECCF16A5 /* SettingsViewModelTests.swift */,
 				C3719FBB51843D5D7E6DD595 /* SharedServicesTests.swift */,
 				ED899AF6D4BE3E29B5D74A55 /* SharedViewModelHelpersTests.swift */,
+				F60F86180BBDA5E9C2473370 /* ShortcutsWiFiProviderTests.swift */,
 				9C8EFF5761E9E21BEF9DA9BF /* SpeedTestToolViewModelTests.swift */,
 				36852127AEB10D1585E9B339 /* SSLCertificateMonitorViewModelTests.swift */,
 				34F859F6CEAF0904E53EAF93 /* SubnetCalculatorToolViewModelTests.swift */,
@@ -2024,6 +2030,7 @@
 				4E634E7C711C966E0522C80F /* PublicIPServiceTests.swift in Sources */,
 				388F2ECC43F6E3F23E726946 /* RateAppServiceTests.swift in Sources */,
 				ED2737886E2DF66E43FDE912 /* RoomPlanScannerViewModelTests.swift in Sources */,
+				7F93CBEDC7BCC5DEDCC39438 /* RoomPlanTaskTimeoutTests.swift in Sources */,
 				2FA2952DA6B61331DBD76D24 /* SSLCertificateMonitorViewModelTests.swift in Sources */,
 				23FA7883EB6A0748810C82FA /* SaveWiFiReadingIntentTests.swift in Sources */,
 				BC490BF14024DA0B461EE38C /* ScanThermalManagerTests.swift in Sources */,
@@ -2031,6 +2038,7 @@
 				9C2FC4CCB191BA03BD340929 /* SettingsViewModelTests.swift in Sources */,
 				778774522039425C97544A15 /* SharedServicesTests.swift in Sources */,
 				15C2A680CD3D446D0E378988 /* SharedViewModelHelpersTests.swift in Sources */,
+				926C48FA20F04F3FCB81A854 /* ShortcutsWiFiProviderTests.swift in Sources */,
 				D28E60CDEB397AC57415859E /* SpeedTestToolViewModelTests.swift in Sources */,
 				16BEA491C1FAAD14D7EADC52 /* SubnetCalculatorToolViewModelTests.swift in Sources */,
 				AA9BB5A6EAD413D9350ED625 /* TargetManagerExtendedTests.swift in Sources */,

--- a/NetMonitor-iOS/Platform/WiFiReadingBridge.swift
+++ b/NetMonitor-iOS/Platform/WiFiReadingBridge.swift
@@ -16,6 +16,12 @@ final class WiFiReadingBridge {
 
     private init() {}
 
+    #if DEBUG
+    /// Test-only initializer. Unit tests need isolated instances; production
+    /// code must continue to use ``shared``.
+    static func makeForTesting() -> WiFiReadingBridge { WiFiReadingBridge() }
+    #endif
+
     // MARK: - Storage
 
     private var pendingContinuations: [UUID: CheckedContinuation<ShortcutsWiFiReading?, Never>] = [:]

--- a/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
@@ -709,18 +709,17 @@ final class RoomPlanScanViewController: UIViewController, RoomCaptureSessionDele
     /// - Throws: `RoomPlanBuildError.fallbackTimeout` if both attempts time out, or
     ///   rethrows any non-timeout `RoomBuilder` conversion error.
     nonisolated private func buildCapturedRoom(from data: CapturedRoomData) async throws -> CapturedRoom {
-        // First attempt with object beautification for cleaner geometry.
-        // If it stalls on very large captures, retry with no options.
-        let beautifiedBuilder = RoomBuilder(options: .beautifyObjects)
+        // RoomBuilder is not Sendable — create inside each closure to avoid capture.
         do {
             return try await RoomPlanTaskTimeout.run(timeout: Self.primaryBuildTimeout) {
-                try await beautifiedBuilder.capturedRoom(from: data)
+                let builder = RoomBuilder(options: .beautifyObjects)
+                return try await builder.capturedRoom(from: data)
             }
         } catch RoomPlanBuildError.timeout {
-            let fallbackBuilder = RoomBuilder(options: [])
             do {
                 return try await RoomPlanTaskTimeout.run(timeout: Self.fallbackBuildTimeout) {
-                    try await fallbackBuilder.capturedRoom(from: data)
+                    let builder = RoomBuilder(options: [])
+                    return try await builder.capturedRoom(from: data)
                 }
             } catch RoomPlanBuildError.timeout {
                 throw RoomPlanBuildError.fallbackTimeout

--- a/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
@@ -928,3 +928,85 @@ struct DeepLinkRouterTests {
         #expect(router.pendingSurveyFileURL == nil)
     }
 }
+
+// MARK: - v2.1 Regression Guards
+
+@MainActor
+struct HeatmapSurveyViewModelRegressionTests {
+
+    private func makeStubbedService(signalDBm: Int) -> IOSHeatmapService {
+        let wifi = MockWiFiInfoService()
+        wifi.currentWiFi = WiFiInfo(
+            ssid: "RegressionNet",
+            bssid: "11:22:33:44:55:66",
+            signalStrength: 80,
+            signalDBm: signalDBm,
+            channel: 6,
+            frequency: "2437 MHz",
+            band: .band2_4GHz,
+            noiseLevel: -90,
+            linkSpeed: 144.0
+        )
+        let speed = MockSpeedTestService()
+        speed.mockResult = SpeedTestData(downloadSpeed: 100, uploadSpeed: 50, latency: 15)
+        let ping = MockPingService()
+        return IOSHeatmapService(
+            wifiInfoService: wifi,
+            speedTestService: speed,
+            pingService: ping
+        )
+    }
+
+    private func makeCalibratedVM() -> HeatmapSurveyViewModel {
+        let vm = HeatmapSurveyViewModel()
+        vm.importFloorPlan(imageData: Data([1]), width: 1000, height: 500)
+        vm.addCalibrationPoint(at: CGPoint.zero)
+        vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
+        vm.completeCalibration(withDistance: 10.0)
+        return vm
+    }
+
+    /// Regression guard for commit 6de9308 (heatmap IOSHeatmapService DI fix).
+    /// Before the fix, `heatmapService` was never injected and every measurement
+    /// silently returned the fallback -100 dBm sentinel. This test proves that
+    /// `configure(service:)` actually routes subsequent `takeMeasurement` calls
+    /// through the injected service.
+    @Test("configure(service:) routes takeMeasurement through the injected service")
+    func configureWiresServiceIntoTakeMeasurement() async {
+        let vm = makeCalibratedVM()
+
+        // Without service: fallback uses currentRSSI default (-100)
+        await vm.takeMeasurement(at: CGPoint(x: 0.1, y: 0.1))
+        let fallbackPoint = vm.measurementPoints.last
+        #expect(fallbackPoint?.rssi == -100)
+
+        // After configure: measurement uses the injected service's WiFiInfo
+        vm.configure(service: makeStubbedService(signalDBm: -45))
+        await vm.takeMeasurement(at: CGPoint(x: 0.2, y: 0.2))
+        let servicedPoint = vm.measurementPoints.last
+        #expect(servicedPoint?.rssi == -45)
+    }
+
+    /// Regression guard for commit 5266185 (shortcuts focus-thrash fix).
+    /// Before the fix, `startSurvey()` called `startSignalPolling()`, which
+    /// invoked the Shortcuts companion every 2s and stole focus back to the
+    /// Shortcuts app, making the survey tool unusable. The fix removed that
+    /// call. This test proves no background task auto-updates `currentRSSI`
+    /// after `startSurvey()` returns.
+    @Test("startSurvey does not start background signal polling")
+    func startSurveyDoesNotStartSignalPolling() async {
+        let vm = makeCalibratedVM()
+        vm.configure(service: makeStubbedService(signalDBm: -45))
+
+        // Seed a sentinel the live-poll loop would overwrite on its first tick.
+        vm.currentRSSI = -77
+
+        vm.startSurvey()
+        #expect(vm.isSurveying == true)
+
+        // If polling were (re-)enabled, the task would fire immediately and
+        // overwrite currentRSSI with the service's -45 well within 300ms.
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(vm.currentRSSI == -77)
+    }
+}

--- a/Tests/NetMonitor-iOSTests/RoomPlanTaskTimeoutTests.swift
+++ b/Tests/NetMonitor-iOSTests/RoomPlanTaskTimeoutTests.swift
@@ -24,4 +24,26 @@ struct RoomPlanTaskTimeoutTests {
             Issue.record("Expected RoomPlanBuildError.timeout, got \(error)")
         }
     }
+
+    /// Regression guard: non-timeout errors thrown by the operation must
+    /// propagate unchanged. Wrapping them as `.timeout` would cause the
+    /// `buildCapturedRoom` fallback path (which pattern-matches on `.timeout`)
+    /// to run a second 30s attempt on deterministic failures, doubling the
+    /// latency before the user sees the real error.
+    @Test func operationErrorRethrownNotWrapped() async {
+        struct SentinelError: Error, Equatable {}
+
+        do {
+            _ = try await RoomPlanTaskTimeout.run(timeout: .seconds(1)) {
+                throw SentinelError()
+            }
+            Issue.record("Expected SentinelError but operation succeeded")
+        } catch is RoomPlanBuildError {
+            Issue.record("SentinelError was wrapped as RoomPlanBuildError — should be rethrown unchanged")
+        } catch is SentinelError {
+            // Expected.
+        } catch {
+            Issue.record("Expected SentinelError, got \(error)")
+        }
+    }
 }

--- a/Tests/NetMonitor-iOSTests/ShortcutsWiFiProviderTests.swift
+++ b/Tests/NetMonitor-iOSTests/ShortcutsWiFiProviderTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+@testable import NetMonitor_iOS
+
+struct ShortcutsWiFiProviderTests {
+
+    /// Regression guard for the 3s → 10s timeout bump.
+    /// Slow devices frequently exceed a 3s Shortcuts round-trip; the shorter
+    /// timeout produced the user-visible "-100 dBm" field incident tracked
+    /// on 2026-04-16. The setup-view copy and the provider constant must
+    /// stay synchronized at 10s.
+    @Test func defaultTimeoutIsTenSeconds() {
+        #expect(ShortcutsWiFiProvider.defaultTimeout == 10.0)
+    }
+}

--- a/Tests/NetMonitor-iOSTests/ShortcutsWiFiProviderTests.swift
+++ b/Tests/NetMonitor-iOSTests/ShortcutsWiFiProviderTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import NetMonitor_iOS
 
+@MainActor
 struct ShortcutsWiFiProviderTests {
 
     /// Regression guard for the 3s → 10s timeout bump.

--- a/Tests/NetMonitor-iOSTests/WiFiReadingBridgeTests.swift
+++ b/Tests/NetMonitor-iOSTests/WiFiReadingBridgeTests.swift
@@ -29,7 +29,7 @@ struct WiFiReadingBridgeTests {
     func publishBeforeWaitReturnsMissedReading() async {
         // Simulate the cold-launch edge case: publish fires before wait is registered.
         // The bridge itself will return nil (no listener); the provider falls back to file.
-        let bridge = WiFiReadingBridge()
+        let bridge = WiFiReadingBridge.makeForTesting()
         let reading = makeReading()
         bridge.publish(reading) // no continuations registered — no-op
 
@@ -42,7 +42,7 @@ struct WiFiReadingBridgeTests {
 
     @Test("publish during waitForReading resolves continuation with reading")
     func publishDuringWaitResolvesReading() async {
-        let bridge = WiFiReadingBridge()
+        let bridge = WiFiReadingBridge.makeForTesting()
         let reading = makeReading(rssi: -55, channel: 36)
 
         // Start waiting, then publish after a small delay.
@@ -63,7 +63,7 @@ struct WiFiReadingBridgeTests {
 
     @Test("waitForReading returns nil after timeout when no publish arrives")
     func waitForReadingTimesOut() async {
-        let bridge = WiFiReadingBridge()
+        let bridge = WiFiReadingBridge.makeForTesting()
         let result = await bridge.waitForReading(timeout: 0.05)
         #expect(result == nil)
     }
@@ -72,7 +72,7 @@ struct WiFiReadingBridgeTests {
 
     @Test("publish resolves all pending continuations")
     func publishResolvesMultipleWaiters() async {
-        let bridge = WiFiReadingBridge()
+        let bridge = WiFiReadingBridge.makeForTesting()
         let reading = makeReading(rssi: -70)
 
         async let r1 = bridge.waitForReading(timeout: 2.0)
@@ -92,7 +92,7 @@ struct WiFiReadingBridgeTests {
 
     @Test("publish after timeout does not double-resume (no crash)")
     func publishAfterTimeoutDoesNotCrash() async {
-        let bridge = WiFiReadingBridge()
+        let bridge = WiFiReadingBridge.makeForTesting()
         let reading = makeReading()
 
         // Wait with a very short timeout so it expires first.

--- a/Tests/NetMonitor-macOSTests/AppearanceModeTests.swift
+++ b/Tests/NetMonitor-macOSTests/AppearanceModeTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import NetMonitor_macOS
+
+struct AppearanceModeTests {
+
+    /// Regression guard for GH-142: `@AppStorage("netmonitor.appearance.theme")`
+    /// reads the raw string from UserDefaults. If the enum raw values, display
+    /// names, or icon names are refactored without care, the picker will silently
+    /// fall back to `.system` for existing users.
+    @Test func rawValuesAreStable() {
+        #expect(AppearanceMode.system.rawValue == "system")
+        #expect(AppearanceMode.dark.rawValue == "dark")
+        #expect(AppearanceMode.light.rawValue == "light")
+    }
+
+    @Test func rawValueRoundTripSucceedsForAllCases() {
+        for mode in AppearanceMode.allCases {
+            let reconstructed = AppearanceMode(rawValue: mode.rawValue)
+            #expect(reconstructed == mode, "AppearanceMode.\(mode) did not round-trip")
+        }
+    }
+
+    @Test func rawValueInitReturnsNilForGarbageInput() {
+        #expect(AppearanceMode(rawValue: "") == nil)
+        #expect(AppearanceMode(rawValue: "Light") == nil) // case-sensitive
+        #expect(AppearanceMode(rawValue: "auto") == nil)
+    }
+
+    @Test func displayNamesAreDistinct() {
+        let names = Set(AppearanceMode.allCases.map(\.displayName))
+        #expect(names.count == AppearanceMode.allCases.count)
+    }
+
+    @Test func iconNamesAreDistinct() {
+        let icons = Set(AppearanceMode.allCases.map(\.iconName))
+        #expect(icons.count == AppearanceMode.allCases.count)
+    }
+}

--- a/Tests/NetMonitor-macOSTests/WiFiHeatmapViewModelSaveLoadTests.swift
+++ b/Tests/NetMonitor-macOSTests/WiFiHeatmapViewModelSaveLoadTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+import NetMonitorCore
+@testable import NetMonitor_macOS
+
+// MARK: - Project Save/Load Roundtrip
+
+@MainActor
+struct WiFiHeatmapViewModelSaveLoadTests {
+
+    /// Regression guard for the v2.1 user-promise that surveys persist across
+    /// relaunch. Only the Core `ProjectSaveLoadManager` was covered by tests;
+    /// the VM-layer glue that assigns `measurementPoints` into the project on
+    /// save and extracts them on load had no coverage.
+    @Test("save/load roundtrip preserves measurement points and calibration")
+    func saveLoadRoundTripPreservesMeasurementsAndCalibration() throws {
+        // 1. Build a calibrated project with a handful of distinctive measurements.
+        let source = WiFiHeatmapViewModel()
+        try source.importFloorPlan(imageData: makeTestPNGData(), name: "RoundTripTest")
+        source.addCalibrationPoint(at: CGPoint(x: 0.1, y: 0.2))
+        source.addCalibrationPoint(at: CGPoint(x: 0.9, y: 0.2))
+        source.completeCalibration(withDistance: 8.0)
+        #expect(source.isCalibrated == true)
+
+        source.measurementPoints = [
+            MeasurementPoint(floorPlanX: 0.15, floorPlanY: 0.15, rssi: -42, ssid: "TestNet"),
+            MeasurementPoint(floorPlanX: 0.55, floorPlanY: 0.55, rssi: -63, ssid: "TestNet"),
+            MeasurementPoint(floorPlanX: 0.85, floorPlanY: 0.85, rssi: -81, ssid: "TestNet"),
+        ]
+
+        // 2. Write to a temp file.
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("heatmap-roundtrip-\(UUID().uuidString).netmonsurvey")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        try source.saveProject(to: tempURL)
+        #expect(FileManager.default.fileExists(atPath: tempURL.path))
+
+        // 3. Load into a pristine VM.
+        let target = WiFiHeatmapViewModel()
+        try target.loadProject(from: tempURL)
+
+        // 4. Measurements preserved by count, coordinates, and RSSI.
+        #expect(target.measurementPoints.count == 3)
+        #expect(target.measurementPoints.map(\.rssi) == [-42, -63, -81])
+        #expect(target.measurementPoints.map(\.floorPlanX) == [0.15, 0.55, 0.85])
+        #expect(target.measurementPoints.map(\.floorPlanY) == [0.15, 0.55, 0.85])
+
+        // 5. Calibration preserved — floor plan retains its scaled dimensions
+        //    and the VM re-enters the calibrated state on load.
+        #expect(target.isCalibrated == true)
+        #expect(target.surveyProject?.floorPlan.calibrationPoints?.count == 2)
+    }
+
+    /// If saveProject is called before a floor plan is imported, it should
+    /// be a no-op rather than producing a malformed file. This protects the
+    /// early-return guard in `saveProject(to:)`.
+    @Test("saveProject is a no-op when no floor plan is loaded")
+    func saveProjectWithoutFloorPlanIsNoOp() throws {
+        let vm = WiFiHeatmapViewModel()
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("heatmap-empty-\(UUID().uuidString).netmonsurvey")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        try vm.saveProject(to: tempURL)
+        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+    }
+}


### PR DESCRIPTION
## Summary

Regression guard tests for recently-shipped v2.1 fixes whose silent-regression risk was flagged in the comprehensive test coverage audit, plus two real bugs that the audit work uncovered on main.

### New tests (13 total, all passing)

**iOS** (`Tests/NetMonitor-iOSTests/`)
- `HeatmapSurveyViewModelRegressionTests.configureWiresServiceIntoTakeMeasurement` — protects the IOSHeatmapService DI fix (6de9308). Without this guard, a refactor could silently return the -100 dBm sentinel for every measurement.
- `HeatmapSurveyViewModelRegressionTests.startSurveyDoesNotStartSignalPolling` — protects the Shortcuts focus-thrash fix (5266185). Any regression that re-enables live polling would make the heatmap tool unusable.
- `RoomPlanTaskTimeoutTests.operationErrorRethrownNotWrapped` — guards timeout helper semantics; prevents non-timeout errors from triggering a second 30s fallback attempt.
- `ShortcutsWiFiProviderTests.defaultTimeoutIsTenSeconds` — locks the 3s→10s timeout bump that fixed the field -100 RSSI incident (2026-04-16).

**macOS** (`Tests/NetMonitor-macOSTests/`)
- `AppearanceModeTests` (5 tests) — raw-value / displayName / iconName contract for GH-142. Refactoring the enum without care would reset every user's theme preference via `@AppStorage`.
- `WiFiHeatmapViewModelSaveLoadTests` (2 tests) — VM-layer save→load roundtrip (measurements + calibration + floor plan). Previously only the Core `ProjectSaveLoadManager` had coverage.

### Bug fixes discovered while running the tests

1. **Restore RoomBuilder Sendable capture fix** (commit `efe3813`). PR #182 merged into main as `dbfa60e` silently lost the 6edf785 fix — iOS builds were failing under Swift 6 strict concurrency on `buildCapturedRoom` because `beautifiedBuilder` / `fallbackBuilder` were captured from outside the `@Sendable` closure. Re-applied the intended fix.
2. **WiFiReadingBridge test seam** (commit `36c8d7b`). The Apr-16 App Intents refactor (01e0d22) made the bridge's `init` `private`, but `WiFiReadingBridgeTests` still constructed instances directly — so the entire Wi-Fi Shortcuts bridge test suite has been silently uncompilable on main since then. Added a DEBUG-only `makeForTesting()` factory; production code continues to use `.shared`.

## Test plan

- [x] `HeatmapSurveyViewModelRegressionTests` — 2/2 ✔ (iPhone 17 simulator)
- [x] `ShortcutsWiFiProviderTests` — 1/1 ✔
- [x] `RoomPlanTaskTimeoutTests` — 3/3 ✔ (2 existing + 1 new)
- [x] `AppearanceModeTests` — 5/5 ✔ (macOS host)
- [x] `WiFiHeatmapViewModelSaveLoadTests` — 2/2 ✔
- [x] iOS build succeeds under Swift 6 strict concurrency (confirmed via full `xcodebuild test` compile on mac-mini)

## Follow-up

This is Batch 1+2 of the v2.1 audit priority-1 list (6 of ~27 tests). Remaining priority-1 items — end-to-end user journeys, XCUITest outcome tests, snapshot tests for light mode — need either XCUITest infra or `SnapshotTesting` package integration before they can be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)