### PR TITLE
fix: Blueprint import renders blank on iOS + macOS file importer rejects ZIP

### DIFF
--- a/NetMonitor-iOS/ViewModels/RoomPlanScannerViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/RoomPlanScannerViewModel.swift
@@ -56,14 +56,25 @@ final class RoomPlanScannerViewModel {
         let blueprint = buildBlueprint(from: room)
         completedBlueprint = blueprint
 
-        // Generate a preview image from the SVG
+        // Generate a preview image from the floor plan
+        // On iOS, UIImage can't render SVG — use direct Core Graphics renderer
         if let floor = blueprint.floors.first {
+            #if canImport(UIKit)
+            let pngData = SVGRenderer.renderWallsToPNG(
+                walls: floor.wallSegments,
+                roomLabels: floor.roomLabels,
+                widthMeters: floor.widthMeters,
+                heightMeters: floor.heightMeters,
+                renderWidth: 800
+            )
+            #else
             let pngData = SVGRenderer.renderToPNG(
                 svgData: floor.svgData,
                 width: 800,
                 heightMeters: floor.heightMeters,
                 widthMeters: floor.widthMeters
             )
+            #endif
             previewImage = UIImage(data: pngData)
         }
 

--- a/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/WiFiHeatmapView.swift
@@ -519,7 +519,10 @@ private extension View {
             }
             .fileImporter(
                 isPresented: showBlueprintImporter,
-                allowedContentTypes: [UTType("com.netmonitor.blueprint") ?? .data],
+                allowedContentTypes: [
+                    UTType("com.netmonitor.blueprint") ?? .data,
+                    .zip  // iOS exports blueprints as ZIP archives via saveAsArchive()
+                ],
                 allowsMultipleSelection: false
             ) { result in
                 onBlueprintImport(result)

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/BlueprintSaveLoadManager.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/BlueprintSaveLoadManager.swift
@@ -258,13 +258,24 @@ public struct BlueprintSaveLoadManager: Sendable {
         _ floor: BlueprintFloor,
         renderWidth: Int = 2048
     ) -> FloorPlan {
-        // Render SVG to PNG for the heatmap canvas
+        // On iOS, UIImage can't render SVG — use direct Core Graphics renderer with wall data.
+        // On macOS, NSImage handles SVG natively.
+        #if canImport(UIKit)
+        let pngData = SVGRenderer.renderWallsToPNG(
+            walls: floor.wallSegments,
+            roomLabels: floor.roomLabels,
+            widthMeters: floor.widthMeters,
+            heightMeters: floor.heightMeters,
+            renderWidth: renderWidth
+        )
+        #else
         let pngData = SVGRenderer.renderToPNG(
             svgData: floor.svgData,
             width: renderWidth,
             heightMeters: floor.heightMeters,
             widthMeters: floor.widthMeters
         )
+        #endif
 
         let aspectRatio = floor.heightMeters / max(floor.widthMeters, 0.001)
         let renderHeight = Int(Double(renderWidth) * aspectRatio)

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
@@ -106,7 +106,10 @@ public enum SVGRenderer: Sendable {
         let scaleX = Double(renderWidth) / widthMeters
         let scaleY = Double(renderHeight) / heightMeters
 
-        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
         return renderer.pngData { context in
             // White background
             UIColor.white.setFill()

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
@@ -94,7 +94,9 @@ public enum SVGRenderer: Sendable {
         heightMeters: Double,
         renderWidth: Int = 2048
     ) -> Data {
-        guard widthMeters > 0, heightMeters > 0 else { return Data() }
+        guard widthMeters > 0,
+              heightMeters > 0,
+              !(walls.isEmpty && roomLabels.isEmpty) else { return Data() }
 
         let aspectRatio = heightMeters / widthMeters
         let renderHeight = max(1, Int(Double(renderWidth) * aspectRatio))

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
@@ -25,7 +25,7 @@ public enum SVGRenderer: Sendable {
         }
 
         let aspectRatio = heightMeters / widthMeters
-        let height = Int(Double(width) * aspectRatio)
+        let height = max(1, Int(Double(width) * aspectRatio))
 
         #if canImport(AppKit)
         return renderWithAppKit(svgData: svgData, width: width, height: height)
@@ -97,7 +97,7 @@ public enum SVGRenderer: Sendable {
         guard widthMeters > 0, heightMeters > 0 else { return Data() }
 
         let aspectRatio = heightMeters / widthMeters
-        let renderHeight = Int(Double(renderWidth) * aspectRatio)
+        let renderHeight = max(1, Int(Double(renderWidth) * aspectRatio))
         let targetSize = CGSize(width: renderWidth, height: renderHeight)
 
         // Scale factor: pixels per meter

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
@@ -84,6 +84,73 @@ public enum SVGRenderer: Sendable {
             }
         }
     }
+
+    /// Renders wall segments directly using Core Graphics (no SVG dependency).
+    /// Used on iOS where UIImage cannot render SVG data.
+    public static func renderWallsToPNG(
+        walls: [WallSegment],
+        roomLabels: [RoomLabel],
+        widthMeters: Double,
+        heightMeters: Double,
+        renderWidth: Int = 2048
+    ) -> Data {
+        guard widthMeters > 0, heightMeters > 0 else { return Data() }
+
+        let aspectRatio = heightMeters / widthMeters
+        let renderHeight = Int(Double(renderWidth) * aspectRatio)
+        let targetSize = CGSize(width: renderWidth, height: renderHeight)
+
+        // Scale factor: pixels per meter
+        let scaleX = Double(renderWidth) / widthMeters
+        let scaleY = Double(renderHeight) / heightMeters
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.pngData { context in
+            // White background
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: targetSize))
+
+            // Draw walls
+            let cgContext = context.cgContext
+            cgContext.setStrokeColor(UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1).cgColor)
+            cgContext.setLineCap(.round)
+
+            for wall in walls {
+                let x1 = wall.startX * scaleX
+                let y1 = wall.startY * scaleY
+                let x2 = wall.endX * scaleX
+                let y2 = wall.endY * scaleY
+                let strokeWidth = max(wall.thickness * min(scaleX, scaleY), 2.0)
+
+                cgContext.setLineWidth(strokeWidth)
+                cgContext.move(to: CGPoint(x: x1, y: y1))
+                cgContext.addLine(to: CGPoint(x: x2, y: y2))
+                cgContext.strokePath()
+            }
+
+            // Draw room labels
+            let fontSize = CGFloat(widthMeters / 10.0 * scaleX) * 0.4
+            let font = UIFont.systemFont(ofSize: max(fontSize, 12))
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: UIColor(red: 0.4, green: 0.4, blue: 0.4, alpha: 1)
+            ]
+
+            let svgW = Double(renderWidth)
+            let svgH = Double(renderHeight)
+
+            for label in roomLabels {
+                let x = label.normalizedX * svgW
+                let y = label.normalizedY * svgH
+                let textSize = (label.text as NSString).size(withAttributes: attrs)
+                let drawPoint = CGPoint(
+                    x: x - textSize.width / 2,
+                    y: y - textSize.height / 2
+                )
+                (label.text as NSString).draw(at: drawPoint, withAttributes: attrs)
+            }
+        }
+    }
     #endif
 }
 

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/Heatmap/SVGRenderer.swift
@@ -129,7 +129,7 @@ public enum SVGRenderer: Sendable {
             }
 
             // Draw room labels
-            let fontSize = CGFloat(widthMeters / 10.0 * scaleX) * 0.4
+            let fontSize = CGFloat(renderWidth) / 25.0
             let font = UIFont.systemFont(ofSize: max(fontSize, 12))
             let attrs: [NSAttributedString.Key: Any] = [
                 .font: font,


### PR DESCRIPTION
## Two fixes for iOS → macOS blueprint import

### 1. iOS blueprint floor plan renders blank
**Root cause:** `UIImage` cannot render SVG data. `SVGRenderer.renderToPNG()` returned empty `Data()` because `UIImage(data: svgData)` is always nil on iOS.

**Fix:** Added `SVGRenderer.renderWallsToPNG()` that draws wall segments and room labels directly using Core Graphics — no SVG dependency. Updated `floorPlanFromBlueprint()` with `#if canImport(UIKit)` branching:
- iOS: direct CG renderer from `WallSegment` data
- macOS: SVG renderer via `NSImage` (unchanged)

Also fixed `RoomPlanScannerViewModel` preview generation (same issue).

### 2. macOS file importer rejects ZIP blueprints from iOS
**Root cause:** iOS `exportBlueprint()` uses `saveAsArchive()` → ZIP file. But macOS `fileImporter` only accepted `com.netmonitor.blueprint` UTI (conforms to `com.apple.package`). ZIP files have `public.zip-archive` type → rejected.

**Fix:** Added `.zip` to the blueprint importer's `allowedContentTypes`. `BlueprintSaveLoadManager.load()` already handles both formats.

### Files changed
- `SVGRenderer.swift` — new `renderWallsToPNG()` for iOS
- `BlueprintSaveLoadManager.swift` — `#if canImport(UIKit)` branch in `floorPlanFromBlueprint()`
- `RoomPlanScannerViewModel.swift` — use direct renderer for preview
- `WiFiHeatmapView.swift` — accept `.zip` in file importer