### PR TITLE
fix: RoomBuilder Sendable capture — create inside @Sendable closures

### DIFF
--- a/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
@@ -619,17 +619,17 @@ final class RoomPlanScanViewController: UIViewController, RoomCaptureSessionDele
     ///   rethrows any non-timeout `RoomBuilder` conversion error.
     nonisolated private func buildCapturedRoom(from data: CapturedRoomData) async throws -> CapturedRoom {
         // First attempt with object beautification for cleaner geometry.
-        // If it stalls on very large captures, retry with no options.
-        let beautifiedBuilder = RoomBuilder(options: .beautifyObjects)
+        // RoomBuilder is not Sendable — create inside each closure to avoid capture.
         do {
             return try await RoomPlanTaskTimeout.run(timeout: Self.primaryBuildTimeout) {
-                try await beautifiedBuilder.capturedRoom(from: data)
+                let builder = RoomBuilder(options: .beautifyObjects)
+                return try await builder.capturedRoom(from: data)
             }
         } catch RoomPlanBuildError.timeout {
-            let fallbackBuilder = RoomBuilder(options: [])
             do {
                 return try await RoomPlanTaskTimeout.run(timeout: Self.fallbackBuildTimeout) {
-                    try await fallbackBuilder.capturedRoom(from: data)
+                    let builder = RoomBuilder(options: [])
+                    return try await builder.capturedRoom(from: data)
                 }
             } catch RoomPlanBuildError.timeout {
                 throw RoomPlanBuildError.fallbackTimeout


### PR DESCRIPTION
RoomBuilder does not conform to Sendable. Creating it outside the @Sendable closure then capturing it triggered Swift 6 strict concurrency errors. Fix: create RoomBuilder instances inside each closure so there is no cross-isolation capture.

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
