### PR TITLE
arch-review: P1 batch (concurrency, DIP, App Intents, Heatmap split)

### DIFF
--- a/NetMonitor-iOS/AppIntents/SaveWiFiReadingIntent.swift
+++ b/NetMonitor-iOS/AppIntents/SaveWiFiReadingIntent.swift
@@ -7,7 +7,7 @@ struct SaveWiFiReadingIntent: AppIntent {
     static let description = IntentDescription(
         "Passes Wi-Fi Get Network Details values to NetMonitor for heatmap surveys. Chain this action after 'Get Network Details' in a Shortcut."
     )
-    nonisolated(unsafe) static var openAppWhenRun: Bool = true
+    static var openAppWhenRun: Bool { true }
 
     @Parameter(title: "Network Name (SSID)") var ssid: String
     @Parameter(title: "BSSID") var bssid: String?

--- a/NetMonitor-iOS/Platform/AppIntents/NetworkStatusIntent.swift
+++ b/NetMonitor-iOS/Platform/AppIntents/NetworkStatusIntent.swift
@@ -10,7 +10,19 @@ struct NetworkStatusIntent: AppIntent {
         categoryName: "Network Tools"
     )
 
-    func perform() async throws -> some IntentResult {
-        return .result()
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let service = await MainActor.run { NetworkMonitorService() }
+        // NWPathMonitor seeds currentPath synchronously, but the first async
+        // callback may carry a more accurate view. Brief wait improves accuracy
+        // without noticeably slowing the intent.
+        try? await Task.sleep(for: .milliseconds(200))
+        let (connected, status) = await MainActor.run {
+            (service.isConnected, service.statusText)
+        }
+
+        let dialog: IntentDialog = connected
+            ? "You're connected via \(status)."
+            : "No network connection detected."
+        return .result(dialog: dialog)
     }
 }

--- a/NetMonitor-iOS/Platform/AppIntents/PingIntent.swift
+++ b/NetMonitor-iOS/Platform/AppIntents/PingIntent.swift
@@ -21,7 +21,7 @@ struct PingIntent: AppIntent {
     )
     var count: Int
 
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
         let trimmed = host.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else {
             throw $host.needsValueError("Enter a hostname or IP address.")
@@ -35,7 +35,24 @@ struct PingIntent: AppIntent {
             results.append(result)
         }
 
-        _ = await service.calculateStatistics(results, requestedCount: count)
-        return .result()
+        guard let stats = await service.calculateStatistics(results, requestedCount: count),
+              stats.received > 0 else {
+            throw PingIntentError.noResponses(host: trimmed)
+        }
+
+        let avg = stats.avgTime
+        let dialog: IntentDialog = "Average latency to \(trimmed) was \(Int(avg.rounded())) ms across \(stats.received) of \(stats.transmitted) pings."
+        return .result(value: avg, dialog: dialog)
+    }
+}
+
+private enum PingIntentError: Error, LocalizedError {
+    case noResponses(host: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noResponses(let host):
+            return "No ping responses received from \(host)."
+        }
     }
 }

--- a/NetMonitor-iOS/Platform/AppIntents/ScanNetworkIntent.swift
+++ b/NetMonitor-iOS/Platform/AppIntents/ScanNetworkIntent.swift
@@ -10,12 +10,14 @@ struct ScanNetworkIntent: AppIntent {
         categoryName: "Network Tools"
     )
 
-    func perform() async throws -> some IntentResult {
+    func perform() async throws -> some IntentResult & ReturnsValue<Int> & ProvidesDialog {
         let service = await MainActor.run { DeviceDiscoveryService.shared }
-
-        // scanNetwork(subnet:) is nonisolated async — call from any context
         await service.scanNetwork(subnet: nil)
+        let count = await MainActor.run { service.discoveredDevices.count }
 
-        return .result()
+        let dialog: IntentDialog = count == 1
+            ? "Found 1 device on your network."
+            : "Found \(count) devices on your network."
+        return .result(value: count, dialog: dialog)
     }
 }

--- a/NetMonitor-iOS/Platform/AppIntents/SpeedTestIntent.swift
+++ b/NetMonitor-iOS/Platform/AppIntents/SpeedTestIntent.swift
@@ -10,18 +10,15 @@ struct SpeedTestIntent: AppIntent {
         categoryName: "Network Tools"
     )
 
-    func perform() async throws -> some IntentResult {
-        // Create service and call startTest() on the main actor
-        let data: SpeedTestData = try await MainActor.run {
-            SpeedTestService()
-        }.startTest()
+    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        let service = await MainActor.run { SpeedTestService() }
+        let data = try await service.startTest()
 
         let dl = formatSpeed(data.downloadSpeed)
         let ul = formatSpeed(data.uploadSpeed)
         let latency = String(format: "%.0f ms", data.latency)
+        let dialog: IntentDialog = "Speed test — \(dl) down, \(ul) up, \(latency) latency."
 
-        _ = "Download: \(dl), Upload: \(ul), Latency: \(latency)"
-        return .result()
+        return .result(value: data.downloadSpeed, dialog: dialog)
     }
-
 }

--- a/NetMonitor-iOS/Platform/HeatmapExporter.swift
+++ b/NetMonitor-iOS/Platform/HeatmapExporter.swift
@@ -1,0 +1,101 @@
+import CoreGraphics
+import Foundation
+import NetMonitorCore
+import UIKit
+
+// MARK: - HeatmapExporter
+
+/// Composites the floor-plan image, the heatmap overlay, and the measurement
+/// dots into a single `UIImage` for share-sheet export.
+///
+/// Extracted from ``HeatmapSurveyViewModel`` as part of #197 Phase 3 so the VM
+/// no longer mixes survey state with Core Graphics rendering.
+struct HeatmapExporter {
+
+    /// RGBA color for a measurement dot at the given RSSI. Mirrors the
+    /// in-canvas color thresholds shown in the live heatmap.
+    static func rssiColor(_ rssi: Int) -> UIColor {
+        switch rssi {
+        case -50...0: .systemGreen
+        case -60 ..< -50: .systemYellow
+        case -70 ..< -60: .systemOrange
+        default: .systemRed
+        }
+    }
+
+    /// Renders the composite export image. Returns `nil` if either the floor
+    /// plan or its image data is missing.
+    func renderImage(
+        floorPlanImage: UIImage?,
+        heatmapImage: CGImage?,
+        points: [MeasurementPoint],
+        heatmapOpacity: Double,
+        canvasSize: CGSize
+    ) -> UIImage? {
+        guard let floorImage = floorPlanImage else { return nil }
+
+        let imageRenderer = UIGraphicsImageRenderer(size: canvasSize)
+        return imageRenderer.image { ctx in
+            // Floor plan base layer
+            floorImage.draw(in: CGRect(origin: .zero, size: canvasSize))
+
+            // Heatmap overlay
+            if let heatmapCG = heatmapImage {
+                let heatmapUI = UIImage(cgImage: heatmapCG)
+                ctx.cgContext.setAlpha(heatmapOpacity)
+                heatmapUI.draw(in: CGRect(origin: .zero, size: canvasSize))
+                ctx.cgContext.setAlpha(1.0)
+            }
+
+            // Measurement dots with glow
+            for point in points {
+                let x = point.floorPlanX * canvasSize.width
+                let y = point.floorPlanY * canvasSize.height
+                let color = Self.rssiColor(point.rssi)
+                let dotRadius: CGFloat = 6
+
+                let glowRect = CGRect(
+                    x: x - dotRadius * 1.5,
+                    y: y - dotRadius * 1.5,
+                    width: dotRadius * 3,
+                    height: dotRadius * 3
+                )
+                ctx.cgContext.setFillColor(color.withAlphaComponent(0.3).cgColor)
+                ctx.cgContext.fillEllipse(in: glowRect)
+
+                let dotRect = CGRect(
+                    x: x - dotRadius,
+                    y: y - dotRadius,
+                    width: dotRadius * 2,
+                    height: dotRadius * 2
+                )
+                ctx.cgContext.setFillColor(color.withAlphaComponent(0.8).cgColor)
+                ctx.cgContext.fillEllipse(in: dotRect)
+
+                let highlightRect = CGRect(x: x - 2, y: y - 2, width: 4, height: 4)
+                ctx.cgContext.setFillColor(UIColor.white.withAlphaComponent(0.6).cgColor)
+                ctx.cgContext.fillEllipse(in: highlightRect)
+            }
+        }
+    }
+
+    /// Writes the project to a temporary `.netmonsurvey` file suitable for
+    /// share-sheet export. Returns `nil` if the write fails.
+    func exportProjectFile(
+        project: SurveyProject,
+        fileManager: HeatmapFileManager
+    ) -> URL? {
+        let fileName = project.name
+            .replacingOccurrences(of: " ", with: "-")
+            .lowercased()
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(fileName).netmonsurvey")
+
+        do {
+            try fileManager.save(project: project, to: tempURL)
+            return tempURL
+        } catch {
+            return nil
+        }
+    }
+}

--- a/NetMonitor-iOS/Platform/HeatmapFileManager.swift
+++ b/NetMonitor-iOS/Platform/HeatmapFileManager.swift
@@ -1,0 +1,104 @@
+import Foundation
+import NetMonitorCore
+
+// MARK: - SavedSurveyInfo
+
+/// Metadata for a .netmonsurvey file discovered in the Documents directory.
+/// Used by `HeatmapProjectsView` to render the saved-projects list.
+struct SavedSurveyInfo: Identifiable {
+    let name: String
+    let url: URL
+    let modifiedDate: Date
+    let fileSize: Int
+
+    var id: URL { url }
+
+    var formattedSize: String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(fileSize))
+    }
+}
+
+// MARK: - HeatmapFileManager
+
+/// File-system facade for heatmap survey persistence. Wraps
+/// ``ProjectSaveLoadManager`` for the binary `.netmonsurvey` format and falls
+/// back to JSON encoding for any other extension. Owns the Documents-directory
+/// enumeration used by the saved-projects list and the autosave URL convention.
+///
+/// Extracted from ``HeatmapSurveyViewModel`` as part of #197 Phase 2 so the VM
+/// no longer mixes survey state with file I/O.
+struct HeatmapFileManager {
+    private let projectManager: ProjectSaveLoadManager
+
+    init(projectManager: ProjectSaveLoadManager = ProjectSaveLoadManager()) {
+        self.projectManager = projectManager
+    }
+
+    // MARK: - Save / Load
+
+    func save(project: SurveyProject, to url: URL) throws {
+        if url.pathExtension == "netmonsurvey" {
+            try projectManager.save(project: project, to: url)
+        } else {
+            let data = try JSONEncoder().encode(project)
+            try data.write(to: url, options: .atomic)
+        }
+    }
+
+    func load(from url: URL) throws -> SurveyProject {
+        if url.pathExtension == "netmonsurvey" {
+            return try projectManager.load(from: url)
+        } else {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(SurveyProject.self, from: data)
+        }
+    }
+
+    /// Auto-save destination for a project of the given name.
+    /// Returns `nil` if the Documents directory is unavailable.
+    func autoSaveURL(for projectName: String) -> URL? {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("\(projectName).netmonsurvey")
+    }
+
+    // MARK: - Enumeration
+
+    /// Lists every `.netmonsurvey` file in the Documents directory, sorted by
+    /// modification date (newest first).
+    static func listSavedProjects() -> [SavedSurveyInfo] {
+        guard let documentsURL = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first
+        else { return [] }
+
+        let fileManager = FileManager.default
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: documentsURL,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: .skipsHiddenFiles
+        ) else { return [] }
+
+        return contents
+            .filter { $0.pathExtension == "netmonsurvey" }
+            .compactMap { url -> SavedSurveyInfo? in
+                let attrs = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+                let name = url.deletingPathExtension().lastPathComponent
+                return SavedSurveyInfo(
+                    name: name,
+                    url: url,
+                    modifiedDate: attrs?.contentModificationDate ?? Date.distantPast,
+                    fileSize: attrs?.fileSize ?? 0
+                )
+            }
+            .sorted { $0.modifiedDate > $1.modifiedDate }
+    }
+
+    /// Deletes a saved project file at the given URL.
+    static func deleteSavedProject(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+}

--- a/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
@@ -117,7 +117,7 @@ final class DashboardViewModel {
 
     /// Rolling latency history from GatewayService (for jitter visualization).
     var latencyHistory: [Double] {
-        (gatewayService as? GatewayService)?.latencyHistory ?? []
+        gatewayService.latencyHistory
     }
 
     /// Real-time anchor latencies (measured on refresh).

--- a/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
@@ -125,28 +125,18 @@ final class HeatmapSurveyViewModel {
     var lastSaveDate: Date?
     private var measurementsSinceLastSave: Int = 0
 
-    // MARK: - Live RSSI Polling
-
-    private var signalPollTask: Task<Void, Never>?
-    /// Adaptive polling interval — increases when Shortcuts round-trip exceeds 1.5s.
-    private var pollInterval: TimeInterval = 2.0
-
     // MARK: - Dependencies
 
     private let renderer: HeatmapRenderer
     private let projectManager: ProjectSaveLoadManager
-    private var heatmapService: IOSHeatmapService?
+    private let heatmapService: any HeatmapServiceProtocol
 
     // MARK: - Init
 
-    init() {
+    init(service: any HeatmapServiceProtocol) {
+        self.heatmapService = service
         renderer = HeatmapRenderer()
         projectManager = ProjectSaveLoadManager()
-    }
-
-    /// Inject the heatmap service after construction (services require DI from the app).
-    func configure(service: IOSHeatmapService) {
-        self.heatmapService = service
     }
 
     // MARK: - Computed
@@ -359,7 +349,6 @@ final class HeatmapSurveyViewModel {
 
     func stopSurvey() {
         isSurveying = false
-        stopSignalPolling()  // idempotent no-op; kept for safety if ever re-enabled
         stopContinuousScanTimer()
         updateHeatmap()
     }
@@ -382,44 +371,6 @@ final class HeatmapSurveyViewModel {
         continuousScanTask = nil
     }
 
-    // MARK: - Live RSSI Polling
-
-    private func startSignalPolling() {
-        signalPollTask?.cancel()
-        signalPollTask = Task<Void, Never> { [weak self] in
-            while !Task.isCancelled {
-                guard let self, let service = self.heatmapService else {
-                    try? await Task.sleep(for: .seconds(2))
-                    continue
-                }
-                let start = ContinuousClock.now
-                let point = await service.takeMeasurement(at: 0, floorPlanY: 0)
-                let elapsed = ContinuousClock.now - start
-
-                if Task.isCancelled { return }
-
-                self.currentRSSI = point.rssi
-                self.currentSSID = point.ssid
-
-                // Adaptive backoff: if round-trip exceeds 1.5s, slow down polling
-                let roundTripSeconds = Double(elapsed.components.seconds)
-                    + Double(elapsed.components.attoseconds) / 1e18
-                if roundTripSeconds > 1.5 {
-                    self.pollInterval = min(self.pollInterval + 0.5, 5.0)
-                } else {
-                    self.pollInterval = max(2.0, self.pollInterval - 0.2)
-                }
-
-                try? await Task.sleep(for: .seconds(self.pollInterval))
-            }
-        }
-    }
-
-    private func stopSignalPolling() {
-        signalPollTask?.cancel()
-        signalPollTask = nil
-    }
-
     // MARK: - Measurement
 
     func takeMeasurement(at normalizedPoint: CGPoint) async {
@@ -434,25 +385,15 @@ final class HeatmapSurveyViewModel {
         saveUndoState()
 
         let point: MeasurementPoint
-        if let service = heatmapService {
-            if measurementMode == .active {
-                point = await service.takeActiveMeasurement(
-                    at: Double(normalizedPoint.x),
-                    floorPlanY: Double(normalizedPoint.y)
-                )
-            } else {
-                point = await service.takeMeasurement(
-                    at: Double(normalizedPoint.x),
-                    floorPlanY: Double(normalizedPoint.y)
-                )
-            }
+        if measurementMode == .active {
+            point = await heatmapService.takeActiveMeasurement(
+                at: Double(normalizedPoint.x),
+                floorPlanY: Double(normalizedPoint.y)
+            )
         } else {
-            // Fallback without service — use current polled values
-            point = MeasurementPoint(
-                floorPlanX: normalizedPoint.x,
-                floorPlanY: normalizedPoint.y,
-                rssi: currentRSSI,
-                ssid: currentSSID
+            point = await heatmapService.takeMeasurement(
+                at: Double(normalizedPoint.x),
+                floorPlanY: Double(normalizedPoint.y)
             )
         }
 

--- a/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
@@ -19,23 +19,6 @@ enum HeatmapError: Error, LocalizedError {
     }
 }
 
-// MARK: - SavedSurveyInfo
-
-struct SavedSurveyInfo: Identifiable {
-    let name: String
-    let url: URL
-    let modifiedDate: Date
-    let fileSize: Int
-
-    var id: URL { url }
-
-    var formattedSize: String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: Int64(fileSize))
-    }
-}
-
 // MARK: - HeatmapSurveyViewModel
 
 /// iOS heatmap survey state management.
@@ -128,15 +111,21 @@ final class HeatmapSurveyViewModel {
     // MARK: - Dependencies
 
     private let renderer: HeatmapRenderer
-    private let projectManager: ProjectSaveLoadManager
+    private let fileManager: HeatmapFileManager
+    private let exporter: HeatmapExporter
     private let heatmapService: any HeatmapServiceProtocol
 
     // MARK: - Init
 
-    init(service: any HeatmapServiceProtocol) {
+    init(
+        service: any HeatmapServiceProtocol,
+        fileManager: HeatmapFileManager = HeatmapFileManager(),
+        exporter: HeatmapExporter = HeatmapExporter()
+    ) {
         self.heatmapService = service
+        self.fileManager = fileManager
+        self.exporter = exporter
         renderer = HeatmapRenderer()
-        projectManager = ProjectSaveLoadManager()
     }
 
     // MARK: - Computed
@@ -483,25 +472,13 @@ final class HeatmapSurveyViewModel {
         defer { isSaving = false }
 
         project.measurementPoints = measurementPoints
-
-        if url.pathExtension == "netmonsurvey" {
-            try projectManager.save(project: project, to: url)
-        } else {
-            let data = try JSONEncoder().encode(project)
-            try data.write(to: url, options: .atomic)
-        }
+        try fileManager.save(project: project, to: url)
         lastSaveDate = Date()
         measurementsSinceLastSave = 0
     }
 
     func loadProject(from url: URL) throws {
-        let project: SurveyProject
-        if url.pathExtension == "netmonsurvey" {
-            project = try projectManager.load(from: url)
-        } else {
-            let data = try Data(contentsOf: url)
-            project = try JSONDecoder().decode(SurveyProject.self, from: data)
-        }
+        let project = try fileManager.load(from: url)
 
         surveyProject = project
         measurementPoints = project.measurementPoints
@@ -514,9 +491,9 @@ final class HeatmapSurveyViewModel {
     }
 
     func autoSave() {
-        guard let project = surveyProject else { return }
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        guard let saveURL = documentsURL?.appendingPathComponent("\(project.name).netmonsurvey") else { return }
+        guard let project = surveyProject,
+              let saveURL = fileManager.autoSaveURL(for: project.name)
+        else { return }
         do {
             try saveProject(to: saveURL)
         } catch {
@@ -524,113 +501,24 @@ final class HeatmapSurveyViewModel {
         }
     }
 
-    // MARK: - Saved Projects
-
-    /// Lists all .netmonsurvey files in the Documents directory.
-    static func listSavedProjects() -> [SavedSurveyInfo] {
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        guard let documentsURL else { return [] }
-
-        let fileManager = FileManager.default
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: documentsURL,
-            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
-            options: .skipsHiddenFiles
-        ) else { return [] }
-
-        return contents
-            .filter { $0.pathExtension == "netmonsurvey" }
-            .compactMap { url -> SavedSurveyInfo? in
-                let attrs = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
-                let name = url.deletingPathExtension().lastPathComponent
-                return SavedSurveyInfo(
-                    name: name,
-                    url: url,
-                    modifiedDate: attrs?.contentModificationDate ?? Date.distantPast,
-                    fileSize: attrs?.fileSize ?? 0
-                )
-            }
-            .sorted { $0.modifiedDate > $1.modifiedDate }
-    }
-
-    /// Deletes a saved project file.
-    static func deleteSavedProject(at url: URL) throws {
-        try FileManager.default.removeItem(at: url)
-    }
-
     // MARK: - Export
 
     func exportImage(canvasSize: CGSize) -> UIImage? {
-        guard let project = surveyProject,
-              let floorImage = floorPlanImage else { return nil }
-
-        let imageRenderer = UIGraphicsImageRenderer(size: canvasSize)
-        return imageRenderer.image { ctx in
-            // Draw floor plan
-            floorImage.draw(in: CGRect(origin: .zero, size: canvasSize))
-
-            // Draw heatmap overlay
-            if let heatmapCG = heatmapImage {
-                let heatmapUI = UIImage(cgImage: heatmapCG)
-                ctx.cgContext.setAlpha(heatmapOpacity)
-                heatmapUI.draw(in: CGRect(origin: .zero, size: canvasSize))
-                ctx.cgContext.setAlpha(1.0)
-            }
-
-            // Draw measurement dots with glow
-            for point in filteredPoints {
-                let x = point.floorPlanX * canvasSize.width
-                let y = point.floorPlanY * canvasSize.height
-                let color = rssiColor(point.rssi)
-                let dotRadius: CGFloat = 6
-
-                // Outer glow
-                let glowRect = CGRect(
-                    x: x - dotRadius * 1.5,
-                    y: y - dotRadius * 1.5,
-                    width: dotRadius * 3,
-                    height: dotRadius * 3
-                )
-                ctx.cgContext.setFillColor(color.withAlphaComponent(0.3).cgColor)
-                ctx.cgContext.fillEllipse(in: glowRect)
-
-                // Inner dot
-                let dotRect = CGRect(
-                    x: x - dotRadius,
-                    y: y - dotRadius,
-                    width: dotRadius * 2,
-                    height: dotRadius * 2
-                )
-                ctx.cgContext.setFillColor(color.withAlphaComponent(0.8).cgColor)
-                ctx.cgContext.fillEllipse(in: dotRect)
-
-                // Center highlight
-                let highlightRect = CGRect(x: x - 2, y: y - 2, width: 4, height: 4)
-                ctx.cgContext.setFillColor(UIColor.white.withAlphaComponent(0.6).cgColor)
-                ctx.cgContext.fillEllipse(in: highlightRect)
-            }
-
-            _ = project
-        }
+        guard surveyProject != nil else { return nil }
+        return exporter.renderImage(
+            floorPlanImage: floorPlanImage,
+            heatmapImage: heatmapImage,
+            points: filteredPoints,
+            heatmapOpacity: heatmapOpacity,
+            canvasSize: canvasSize
+        )
     }
 
     /// Exports the project as a .netmonsurvey file URL for sharing.
     func exportProjectFile() -> URL? {
         guard var project = surveyProject else { return nil }
         project.measurementPoints = measurementPoints
-
-        let fileName = project.name
-            .replacingOccurrences(of: " ", with: "-")
-            .lowercased()
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(fileName).netmonsurvey")
-
-        do {
-            try projectManager.save(project: project, to: tempURL)
-            return tempURL
-        } catch {
-            return nil
-        }
+        return exporter.exportProjectFile(project: project, fileManager: fileManager)
     }
 
     // MARK: - Helpers

--- a/NetMonitor-iOS/ViewModels/NetworkHealthScoreViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/NetworkHealthScoreViewModel.swift
@@ -93,16 +93,14 @@ final class NetworkHealthScoreViewModel {
             packetLoss = Double(results.count - successful.count) / Double(results.count)
         }
 
-        if let svc = service as? NetworkHealthScoreService {
-            svc.update(
-                latencyMs: latencyMs,
-                packetLoss: packetLoss,
-                dnsResponseMs: nil,
-                deviceCount: nil,
-                typicalDeviceCount: nil,
-                isConnected: networkMonitor.isConnected
-            )
-        }
+        service.update(
+            latencyMs: latencyMs,
+            packetLoss: packetLoss,
+            dnsResponseMs: nil,
+            deviceCount: nil,
+            typicalDeviceCount: nil,
+            isConnected: networkMonitor.isConnected
+        )
 
         let score = await service.calculateScore()
         currentScore = score

--- a/NetMonitor-iOS/Views/Heatmap/HeatmapProjectsView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/HeatmapProjectsView.swift
@@ -145,11 +145,11 @@ struct HeatmapProjectsView: View {
     // MARK: - Actions
 
     private func refreshProjects() {
-        projects = HeatmapSurveyViewModel.listSavedProjects()
+        projects = HeatmapFileManager.listSavedProjects()
     }
 
     private func deleteProject(_ project: SavedSurveyInfo) {
-        try? HeatmapSurveyViewModel.deleteSavedProject(at: project.url)
+        try? HeatmapFileManager.deleteSavedProject(at: project.url)
         refreshProjects()
     }
 }

--- a/NetMonitor-iOS/Views/Heatmap/HeatmapSurveyView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/HeatmapSurveyView.swift
@@ -7,7 +7,7 @@ import UniformTypeIdentifiers
 
 struct HeatmapSurveyView: View {
     @Environment(DeepLinkRouter.self) private var deepLinkRouter: DeepLinkRouter?
-    @State private var viewModel = HeatmapSurveyViewModel()
+    @State private var viewModel: HeatmapSurveyViewModel
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var showImportOptions = false
     @State private var showRoomScanner = false
@@ -15,7 +15,19 @@ struct HeatmapSurveyView: View {
     @State private var showProjectsList = false
     @State private var shareItems: [Any] = []
     @State private var showShortcutSetup = false
-    @State private var shortcutsProvider = ShortcutsWiFiProvider()
+    @State private var shortcutsProvider: ShortcutsWiFiProvider
+
+    init() {
+        let provider = ShortcutsWiFiProvider()
+        let service = IOSHeatmapService(
+            wifiInfoService: WiFiInfoService(),
+            shortcutsProvider: provider,
+            speedTestService: SpeedTestService(),
+            pingService: PingService()
+        )
+        _shortcutsProvider = State(initialValue: provider)
+        _viewModel = State(initialValue: HeatmapSurveyViewModel(service: service))
+    }
 
     var body: some View {
         ZStack {
@@ -103,17 +115,6 @@ struct HeatmapSurveyView: View {
         }
         .accessibilityIdentifier("screen_heatmapSurvey")
         .onAppear {
-            // Inject the heatmap service. Without this, HeatmapSurveyViewModel
-            // falls back to the nil-service path and every measurement's RSSI
-            // defaults to the -100 sentinel.
-            let service = IOSHeatmapService(
-                wifiInfoService: WiFiInfoService(),
-                shortcutsProvider: shortcutsProvider,
-                speedTestService: SpeedTestService(),
-                pingService: PingService()
-            )
-            viewModel.configure(service: service)
-
             // Check if a .netmonsurvey file was opened via deep link
             if let url = deepLinkRouter?.consumePendingFile() {
                 openFileFromDeepLink(url)

--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -2,6 +2,7 @@
 import Foundation
 import SwiftData
 import NetMonitorCore
+import NetworkScanKit
 import Darwin
 import os
 
@@ -212,12 +213,21 @@ final class DeviceDiscoveryCoordinator {
     /// Ping each online device (3 probes, 2s timeout) and store best latency.
     /// Uses ShellPingService (/sbin/ping) which works within the sandbox via shell,
     /// unlike ICMPSocket which requires a raw socket entitlement we don't have.
+    ///
+    /// Sliding-window cap (matches `resolveDeviceNames` below) — without this we
+    /// fork one `/sbin/ping` subprocess per online device, which spikes CPU and
+    /// trips thermal throttling on 200+ device networks. See #195.
     private func measureDeviceLatencies(profileID: UUID?) async {
         let devices = fetchDevices(for: profileID).filter { $0.status == .online }
         guard !devices.isEmpty else { return }
 
+        let concurrencyLimit = ThermalThrottleMonitor.shared.effectiveLimit(from: 10)
+
         await withTaskGroup(of: (String, Double?).self) { group in
-            for device in devices {
+            var activeCount = 0
+            var iter = devices.makeIterator()
+
+            while activeCount < concurrencyLimit, let device = iter.next() {
                 let ip = device.ipAddress
                 group.addTask {
                     let pingService = ShellPingService()
@@ -225,11 +235,21 @@ final class DeviceDiscoveryCoordinator {
                     let latency = result?.isReachable == true ? result?.minLatency : nil
                     return (ip, latency)
                 }
+                activeCount += 1
             }
 
             for await (ip, latency) in group {
                 if let latency, let device = devices.first(where: { $0.ipAddress == ip }) {
                     device.updateLatency(latency)
+                }
+                if let next = iter.next() {
+                    let nextIP = next.ipAddress
+                    group.addTask {
+                        let pingService = ShellPingService()
+                        let result = try? await pingService.ping(host: nextIP, count: 3, timeout: 2)
+                        let latency = result?.isReachable == true ? result?.minLatency : nil
+                        return (nextIP, latency)
+                    }
                 }
             }
         }

--- a/NetMonitor-macOS/Platform/WiFiHeatmapService.swift
+++ b/NetMonitor-macOS/Platform/WiFiHeatmapService.swift
@@ -14,6 +14,29 @@ struct NearbyAP: Identifiable {
     let noise: Int?
 }
 
+// MARK: - SignalSnapshot
+
+struct SignalSnapshot {
+    let rssi: Int
+    let noiseFloor: Int?
+    let snr: Int?
+    let ssid: String?
+    let bssid: String?
+    let channel: Int?
+    let band: WiFiBand?
+    let linkSpeed: Int?
+    let frequency: Double?
+}
+
+// MARK: - MacWiFiSignalProviding
+
+/// Abstracts live macOS Wi-Fi signal capture so heatmap-style ViewModels
+/// can be exercised with stubs in tests.
+protocol MacWiFiSignalProviding: Sendable {
+    @MainActor func currentSignal() -> SignalSnapshot?
+    func scanForNearbyAPs() -> [NearbyAP]
+}
+
 // MARK: - WiFiHeatmapService
 
 /// CoreWLAN wrapper providing live signal data and nearby AP scanning for the heatmap tool.
@@ -21,7 +44,7 @@ struct NearbyAP: Identifiable {
 /// `scanForNearbyAPs()` is blocking (3-10s) and nonisolated — callers must dispatch it
 /// off the main thread via Task.detached.
 @MainActor
-final class WiFiHeatmapService: @unchecked Sendable {
+final class WiFiHeatmapService: MacWiFiSignalProviding, @unchecked Sendable {
 
     nonisolated let interfaceName: String?
 
@@ -36,18 +59,6 @@ final class WiFiHeatmapService: @unchecked Sendable {
     }
 
     // MARK: - Live Signal
-
-    struct SignalSnapshot {
-        let rssi: Int
-        let noiseFloor: Int?
-        let snr: Int?
-        let ssid: String?
-        let bssid: String?
-        let channel: Int?
-        let band: WiFiBand?
-        let linkSpeed: Int?
-        let frequency: Double?
-    }
 
     func currentSignal() -> SignalSnapshot? {
         guard let iface, iface.powerOn() else { return nil }

--- a/NetMonitor-macOS/ViewModels/WiFiHeatmapViewModel.swift
+++ b/NetMonitor-macOS/ViewModels/WiFiHeatmapViewModel.swift
@@ -23,7 +23,7 @@ final class WiFiHeatmapViewModel {
 
     // MARK: - Live Signal
 
-    private(set) var currentSignal: WiFiHeatmapService.SignalSnapshot?
+    private(set) var currentSignal: SignalSnapshot?
     private(set) var nearbyAPs: [NearbyAP] = []
     private(set) var isScanning: Bool = false
 
@@ -90,7 +90,7 @@ final class WiFiHeatmapViewModel {
 
     // MARK: - Services
 
-    private let heatmapService = WiFiHeatmapService()
+    private let heatmapService: any MacWiFiSignalProviding
     private var wifiEngine: WiFiMeasurementEngine?
     private var signalPollTask: Task<Void, Never>?
     private let renderer: HeatmapRenderer
@@ -101,7 +101,8 @@ final class WiFiHeatmapViewModel {
 
     // MARK: - Init
 
-    init() {
+    init(heatmapService: any MacWiFiSignalProviding = WiFiHeatmapService()) {
+        self.heatmapService = heatmapService
         renderer = HeatmapRenderer()
         setupEngine()
     }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
@@ -142,6 +142,9 @@ public protocol DeviceDiscoveryServiceProtocol: AnyObject, Sendable {
 public protocol GatewayServiceProtocol {
     @MainActor var gateway: GatewayInfo? { get }
     @MainActor var isLoading: Bool { get }
+    /// Rolling history of recent gateway latency measurements (newest first).
+    /// Conformers may return an empty array if no history is tracked.
+    @MainActor var latencyHistory: [Double] { get }
     @MainActor func detectGateway() async
 }
 
@@ -349,6 +352,15 @@ public protocol SSLCertificateServiceProtocol: AnyObject, Sendable {
 
 /// Protocol for computing an overall network health score.
 public protocol NetworkHealthScoreServiceProtocol: AnyObject, Sendable {
+    /// Update cached measurements used by `calculateScore()`.
+    func update(
+        latencyMs: Double?,
+        packetLoss: Double?,
+        dnsResponseMs: Double?,
+        deviceCount: Int?,
+        typicalDeviceCount: Int?,
+        isConnected: Bool
+    )
     func calculateScore() async -> NetworkHealthScore
 }
 

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingService.swift
@@ -9,20 +9,30 @@ import os.log
 ///
 /// Free tier: 100 measurements/hour, no API key required.
 /// ~600 probes across 6 continents.
+///
+/// SAFETY: @unchecked Sendable is safe here because all mutable state (`_lastError`)
+/// is protected by `lock` (NSLock). `session` and `baseURL` are immutable. `logger`
+/// is a Sendable value. All public reads of `lastError` and all writes go through
+/// the lock.
 public final class WorldPingService: WorldPingServiceProtocol, @unchecked Sendable {
     private let session: URLSession
     private let baseURL = "https://api.globalping.io/v1"
     private let logger = Logger(subsystem: "com.netmonitor", category: "WorldPingService")
 
+    private let lock = NSLock()
+    private var _lastError: String?
+
     /// Set after a ping attempt fails. Cleared at the start of each new ping.
-    public private(set) var lastError: String?
+    public var lastError: String? {
+        lock.withLock { _lastError }
+    }
 
     public init(session: URLSession = .shared) {
         self.session = session
     }
 
     public func ping(host: String, maxNodes: Int) async -> AsyncStream<WorldPingLocationResult> {
-        lastError = nil
+        setLastError(nil)
         logger.info("World ping starting for host: \(host), maxNodes: \(maxNodes)")
         return AsyncStream { continuation in
             Task {
@@ -35,11 +45,15 @@ public final class WorldPingService: WorldPingServiceProtocol, @unchecked Sendab
                     }
                 } catch {
                     self.logger.error("World ping failed: \(error.localizedDescription)")
-                    self.lastError = error.localizedDescription
+                    self.setLastError(error.localizedDescription)
                 }
                 continuation.finish()
             }
         }
+    }
+
+    private func setLastError(_ value: String?) {
+        lock.withLock { _lastError = value }
     }
 
     // MARK: - API Calls

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
@@ -213,7 +213,6 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
 
     private static func probePort(ip: String, port: UInt16, timeout: Duration) async -> PortProbeOutcome {
         await ConnectionBudget.shared.acquire()
-        defer { Task { await ConnectionBudget.shared.release() } }
 
         let host = NWEndpoint.Host(ip)
         let endpoint = NWEndpoint.hostPort(host: host, port: NWEndpoint.Port(rawValue: port)!)
@@ -272,6 +271,11 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         }
 
         connection.cancel()
+        // Release synchronously *before* return so the next acquire() sees the
+        // released slot. Wrapping in `Task { ... }` (the old `defer { Task { ... } }`
+        // pattern) detaches release into a later async context, so callers can pile
+        // up past the budget. See #194.
+        await ConnectionBudget.shared.release()
         return result
     }
 
@@ -336,11 +340,10 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
     /// returns as soon as any responds.
     private static func quickLatencyProbe(ip: String, timeout: Duration) async -> Double? {
         await ConnectionBudget.shared.acquire()
-        defer { Task { await ConnectionBudget.shared.release() } }
 
         let host = NWEndpoint.Host(ip)
 
-        return await withTaskGroup(of: Double?.self, returning: Double?.self) { group in
+        let result = await withTaskGroup(of: Double?.self, returning: Double?.self) { group in
             for port in latencyProbePorts {
                 group.addTask {
                     await singlePortLatencyProbe(host: host, port: port, timeout: timeout)
@@ -356,6 +359,10 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             }
             return nil
         }
+
+        // Release synchronously before return — see comment in probePort. See #194.
+        await ConnectionBudget.shared.release()
+        return result
     }
 
     /// Single-port TCP connect for latency measurement.

--- a/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
+++ b/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
@@ -98,9 +98,14 @@ struct NetworkStatusIntentTests {
 @MainActor
 struct NetMonitorShortcutsTests {
 
-    @Test("shortcuts provider has 4 shortcuts")
-    func shortcutCount() {
+    @Test("shortcuts provider includes all expected entries")
+    func shortcutMembership() {
         let shortcuts = NetMonitorShortcuts.appShortcuts
-        #expect(shortcuts.count == 4)
+        let titles = shortcuts.map { String(localized: $0.shortTitle) }
+        #expect(titles.contains("Ping Host"))
+        #expect(titles.contains("Scan Network"))
+        #expect(titles.contains("Speed Test"))
+        #expect(titles.contains("Network Status"))
+        #expect(titles.contains("Save Wi-Fi Reading"))
     }
 }

--- a/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
@@ -253,10 +253,13 @@ struct DashboardViewModelTests {
         #expect(!vm.anchorLatencies.isEmpty)
     }
 
-    @Test func latencyHistoryEmptyWhenGatewayServiceIsMock() {
-        // MockGatewayService is not a GatewayService instance, so the cast fails → returns []
-        let vm = makeVM(gatewayService: MockGatewayService())
+    @Test func latencyHistoryFromGatewayService() {
+        let gateway = MockGatewayService()
+        let vm = makeVM(gatewayService: gateway)
         #expect(vm.latencyHistory.isEmpty)
+
+        gateway.latencyHistory = [12.0, 14.5, 11.2]
+        #expect(vm.latencyHistory == [12.0, 14.5, 11.2])
     }
 
     @Test func recentEventsReflectsToolActivityLog() {

--- a/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import NetMonitor_iOS
 import NetMonitorCore
 
+// MARK: - Test Helpers
+
+@MainActor
+private func makeHeatmapVM(service: any HeatmapServiceProtocol = MockHeatmapService()) -> HeatmapSurveyViewModel {
+    HeatmapSurveyViewModel(service: service)
+}
+
 // MARK: - HeatmapSurveyViewModel Init Tests
 
 @MainActor
@@ -10,67 +17,67 @@ struct HeatmapSurveyViewModelInitTests {
 
     @Test("initial surveyProject is nil")
     func initialSurveyProjectIsNil() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.surveyProject == nil)
     }
 
     @Test("initial measurementPoints is empty")
     func initialMeasurementPointsEmpty() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.measurementPoints.isEmpty)
     }
 
     @Test("initial selectedVisualization is signalStrength")
     func initialVisualizationIsSignalStrength() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.selectedVisualization == .signalStrength)
     }
 
     @Test("initial measurementMode is passive")
     func initialMeasurementModeIsPassive() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.measurementMode == .passive)
     }
 
     @Test("initial isMeasuring is false")
     func initialIsMeasuringIsFalse() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.isMeasuring == false)
     }
 
     @Test("initial showImportSheet is false")
     func initialShowImportSheetIsFalse() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.showImportSheet == false)
     }
 
     @Test("initial currentRSSI is -100")
     func initialCurrentRSSIIsDefault() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.currentRSSI == -100)
     }
 
     @Test("initial currentSSID is nil")
     func initialCurrentSSIDIsNil() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.currentSSID == nil)
     }
 
     @Test("initial isCalibrating is false")
     func initialIsCalibratingIsFalse() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.isCalibrating == false)
     }
 
     @Test("initial calibrationPoints is empty")
     func initialCalibrationPointsEmpty() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.calibrationPoints.isEmpty)
     }
 
     @Test("initial calibrationDistance is 5.0 meters")
     func initialCalibrationDistance() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.calibrationDistance == 5.0)
     }
 }
@@ -82,14 +89,14 @@ struct HeatmapSurveyViewModelImportTests {
 
     @Test("importFloorPlan creates a surveyProject")
     func importFloorPlanCreatesSurveyProject() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([0x89, 0x50, 0x4E, 0x47]), width: 800, height: 600)
         #expect(vm.surveyProject != nil)
     }
 
     @Test("importFloorPlan sets correct pixel dimensions on floorPlan")
     func importFloorPlanSetsPixelDimensions() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1, 2, 3]), width: 1920, height: 1080)
         #expect(vm.surveyProject?.floorPlan.pixelWidth == 1920)
         #expect(vm.surveyProject?.floorPlan.pixelHeight == 1080)
@@ -97,14 +104,14 @@ struct HeatmapSurveyViewModelImportTests {
 
     @Test("importFloorPlan sets floorPlan origin to imported")
     func importFloorPlanSetsOriginToImported() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         #expect(vm.surveyProject?.floorPlan.origin == .imported)
     }
 
     @Test("importFloorPlan clears existing measurementPoints")
     func importFloorPlanClearsMeasurementPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [MeasurementPoint(rssi: -50)]
         vm.importFloorPlan(imageData: Data([1]), width: 200, height: 200)
         #expect(vm.measurementPoints.isEmpty)
@@ -112,7 +119,7 @@ struct HeatmapSurveyViewModelImportTests {
 
     @Test("importFloorPlan clears existing calibrationPoints")
     func importFloorPlanClearsCalibrationPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.calibrationPoints = [CalibrationPoint(pixelX: 10, pixelY: 20)]
         vm.importFloorPlan(imageData: Data([1]), width: 200, height: 200)
         #expect(vm.calibrationPoints.isEmpty)
@@ -120,7 +127,7 @@ struct HeatmapSurveyViewModelImportTests {
 
     @Test("importFloorPlan stores imageData on floorPlan")
     func importFloorPlanStoresImageData() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let data = Data([0x01, 0x02, 0x03, 0x04])
         vm.importFloorPlan(imageData: data, width: 50, height: 50)
         #expect(vm.surveyProject?.floorPlan.imageData == data)
@@ -134,14 +141,14 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("startCalibration sets isCalibrating to true")
     func startCalibrationSetsIsCalibrating() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.startCalibration()
         #expect(vm.isCalibrating == true)
     }
 
     @Test("startCalibration clears calibrationPoints")
     func startCalibrationClearsPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.calibrationPoints = [CalibrationPoint(pixelX: 10, pixelY: 20)]
         vm.startCalibration()
         #expect(vm.calibrationPoints.isEmpty)
@@ -149,7 +156,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("cancelCalibration sets isCalibrating to false")
     func cancelCalibrationResetsFlag() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.startCalibration()
         vm.cancelCalibration()
         #expect(vm.isCalibrating == false)
@@ -157,7 +164,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("cancelCalibration clears calibrationPoints")
     func cancelCalibrationClearsPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.startCalibration()
         vm.addCalibrationPoint(at: CGPoint(x: 0.2, y: 0.3))
         vm.cancelCalibration()
@@ -166,7 +173,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("addCalibrationPoint appends a point")
     func addCalibrationPointAppends() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.addCalibrationPoint(at: CGPoint(x: 0.1, y: 0.4))
         #expect(vm.calibrationPoints.count == 1)
         #expect(vm.calibrationPoints[0].pixelX == 0.1)
@@ -175,7 +182,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("addCalibrationPoint does not exceed 2 points")
     func addCalibrationPointCapsAtTwo() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.addCalibrationPoint(at: CGPoint(x: 0.1, y: 0.2))
         vm.addCalibrationPoint(at: CGPoint(x: 0.5, y: 0.6))
         vm.addCalibrationPoint(at: CGPoint(x: 0.9, y: 0.8))  // should be ignored
@@ -184,7 +191,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("addCalibrationPoint sets showCalibrationSheet when second point added")
     func addSecondCalibrationPointOpensSheet() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.addCalibrationPoint(at: CGPoint(x: 0.1, y: 0.2))
         #expect(vm.showCalibrationSheet == false)
         vm.addCalibrationPoint(at: CGPoint(x: 0.5, y: 0.6))
@@ -193,7 +200,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration updates floorPlan widthMeters and heightMeters")
     func completeCalibrationUpdatesFloorPlanScale() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 1000, height: 500)
 
         vm.addCalibrationPoint(at: CGPoint.zero)
@@ -206,7 +213,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration sets isCalibrating to false")
     func completeCalibrationResetsFlag() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 800, height: 600)
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
@@ -217,7 +224,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration stores calibrationPoints on floorPlan")
     func completeCalibrationStoresPointsOnFloorPlan() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 800, height: 600)
         vm.addCalibrationPoint(at: CGPoint(x: 10, y: 20))
         vm.addCalibrationPoint(at: CGPoint(x: 50, y: 20))
@@ -227,7 +234,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration clears calibrationPoints array")
     func completeCalibrationClearsArray() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 800, height: 600)
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
@@ -237,7 +244,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration does nothing without a survey project")
     func completeCalibrationNoOpWithoutProject() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
         vm.completeCalibration(withDistance: 5.0)
@@ -246,7 +253,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("skipCalibration sets isCalibrated to true")
     func skipCalibrationSetsCalibrated() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.skipCalibration()
         #expect(vm.isCalibrated == true)
         #expect(vm.isCalibrating == false)
@@ -254,7 +261,7 @@ struct HeatmapSurveyViewModelCalibrationTests {
 
     @Test("completeCalibration with feet converts to meters")
     func completeCalibrationWithFeetConverts() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 1000, height: 500)
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100.0, y: 0.0))
@@ -272,7 +279,7 @@ struct HeatmapSurveyViewModelClearTests {
 
     @Test("clearMeasurements empties measurementPoints")
     func clearMeasurementsEmptiesPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -50),
             MeasurementPoint(rssi: -60),
@@ -283,7 +290,7 @@ struct HeatmapSurveyViewModelClearTests {
 
     @Test("clearMeasurements preserves surveyProject")
     func clearMeasurementsPreservesProject() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         vm.measurementPoints = [MeasurementPoint(rssi: -55)]
         vm.clearMeasurements()
@@ -298,14 +305,14 @@ struct HeatmapSurveyViewModelVisualizationTests {
 
     @Test("selectedVisualization can be changed")
     func changeVisualization() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.selectedVisualization = .downloadSpeed
         #expect(vm.selectedVisualization == .downloadSpeed)
     }
 
     @Test("measurementMode can be switched to active")
     func changeMeasurementModeToActive() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementMode = .active
         #expect(vm.measurementMode == .active)
     }
@@ -320,7 +327,7 @@ struct HeatmapSurveyViewModelVisualizationTests {
 
     @Test("switching visualization updates selectedVisualization correctly for all modes")
     func switchAllVisualizationModes() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         for viz in HeatmapVisualization.allCases {
             vm.selectedVisualization = viz
             #expect(vm.selectedVisualization == viz)
@@ -329,7 +336,7 @@ struct HeatmapSurveyViewModelVisualizationTests {
 
     @Test("switching color scheme updates selectedColorScheme correctly for all schemes")
     func switchAllColorSchemes() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         for scheme in HeatmapColorScheme.allCases {
             vm.selectedColorScheme = scheme
             #expect(vm.selectedColorScheme == scheme)
@@ -353,7 +360,7 @@ struct HeatmapSurveyViewModelUndoTests {
 
     @Test("undo restores previous measurement state")
     func undoRestoresPreviousState() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         vm.skipCalibration()
 
@@ -381,13 +388,13 @@ struct HeatmapSurveyViewModelUndoTests {
 
     @Test("canUndo is false when no undo history exists")
     func canUndoFalseInitially() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.canUndo == false)
     }
 
     @Test("canUndo is true after a measurement operation")
     func canUndoTrueAfterDelete() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let point = MeasurementPoint(rssi: -50)
         vm.measurementPoints = [point]
         vm.deleteMeasurement(id: point.id)
@@ -396,7 +403,7 @@ struct HeatmapSurveyViewModelUndoTests {
 
     @Test("undo after clearMeasurements restores all points")
     func undoAfterClearRestoresPoints() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let points = [
             MeasurementPoint(rssi: -40),
             MeasurementPoint(rssi: -50),
@@ -417,7 +424,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("deleteMeasurement removes the correct point by ID")
     func deleteMeasurementRemovesCorrectPoint() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let point1 = MeasurementPoint(rssi: -40, ssid: "Net1")
         let point2 = MeasurementPoint(rssi: -50, ssid: "Net2")
         let point3 = MeasurementPoint(rssi: -60, ssid: "Net3")
@@ -431,7 +438,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("filteredPoints returns all when no AP filter set")
     func filteredPointsReturnsAllWithoutFilter() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -40, bssid: "AA:BB:CC:DD:EE:01"),
             MeasurementPoint(rssi: -50, bssid: "AA:BB:CC:DD:EE:02"),
@@ -441,7 +448,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("filteredPoints filters by BSSID when AP filter is set")
     func filteredPointsFiltersByBSSID() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -40, bssid: "AA:BB:CC:DD:EE:01"),
             MeasurementPoint(rssi: -50, bssid: "AA:BB:CC:DD:EE:02"),
@@ -454,7 +461,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("averageRSSI computes correct average")
     func averageRSSIComputesCorrectly() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -40),
             MeasurementPoint(rssi: -60),
@@ -465,13 +472,13 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("averageRSSI returns nil when no points")
     func averageRSSINilWhenEmpty() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.averageRSSI == nil)
     }
 
     @Test("minRSSI and maxRSSI return correct extremes")
     func minMaxRSSICorrect() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -30),
             MeasurementPoint(rssi: -80),
@@ -483,7 +490,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("qualityLabel returns correct label for RSSI ranges")
     func qualityLabelReturnsCorrectLabels() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         #expect(vm.qualityLabel(-30) == "Excellent")
         #expect(vm.qualityLabel(-55) == "Good")
         #expect(vm.qualityLabel(-65) == "Fair")
@@ -492,7 +499,7 @@ struct HeatmapSurveyViewModelPointManagementTests {
 
     @Test("uniqueBSSIDs groups measurement points by BSSID")
     func uniqueBSSIDsGroupsCorrectly() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.measurementPoints = [
             MeasurementPoint(rssi: -40, ssid: "Net1", bssid: "AA:BB:01"),
             MeasurementPoint(rssi: -50, ssid: "Net2", bssid: "AA:BB:02"),
@@ -510,7 +517,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("saveProject does not throw when surveyProject is nil")
     func saveProjectNoOpWithoutProject() throws {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test-\(UUID().uuidString).json")
         try vm.saveProject(to: url)
         #expect(vm.surveyProject == nil)
@@ -518,7 +525,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("save and load round-trip preserves project data")
     func saveLoadRoundTripPreservesData() throws {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([0x89, 0x50, 0x4E, 0x47]), width: 400, height: 300)
         vm.measurementPoints = [
             MeasurementPoint(rssi: -45, ssid: "Office", bssid: "AA:BB:CC:DD:EE:01"),
@@ -531,7 +538,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
         try vm.saveProject(to: url)
 
-        let vm2 = HeatmapSurveyViewModel()
+        let vm2 = makeHeatmapVM()
         try vm2.loadProject(from: url)
 
         #expect(vm2.surveyProject != nil)
@@ -544,7 +551,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("save and load round-trip as .netmonsurvey preserves floor plan image")
     func netmonSurveyRoundTripPreservesImage() throws {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let imageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
         vm.importFloorPlan(imageData: imageData, width: 200, height: 150)
 
@@ -554,7 +561,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
         try vm.saveProject(to: url)
 
-        let vm2 = HeatmapSurveyViewModel()
+        let vm2 = makeHeatmapVM()
         try vm2.loadProject(from: url)
 
         #expect(vm2.surveyProject?.floorPlan.imageData == imageData)
@@ -564,7 +571,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("save updates lastSaveDate and resets measurementsSinceLastSave")
     func saveUpdatesLastSaveDate() throws {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
 
         #expect(vm.lastSaveDate == nil)
@@ -579,7 +586,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("loadProject restores calibration state")
     func loadProjectRestoresCalibrationState() throws {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 800, height: 600)
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
@@ -591,7 +598,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
         try vm.saveProject(to: url)
 
-        let vm2 = HeatmapSurveyViewModel()
+        let vm2 = makeHeatmapVM()
         try vm2.loadProject(from: url)
 
         #expect(vm2.isCalibrated == true)
@@ -600,7 +607,7 @@ struct HeatmapSurveyViewModelSaveLoadTests {
 
     @Test("exportProjectFile returns a valid URL")
     func exportProjectFileReturnsURL() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1, 2, 3]), width: 100, height: 100)
         vm.measurementPoints = [MeasurementPoint(rssi: -50)]
 
@@ -620,7 +627,7 @@ struct HeatmapSurveyViewModelSurveyControlTests {
 
     @Test("startSurvey requires calibration")
     func startSurveyRequiresCalibration() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         // Not calibrated
         vm.startSurvey()
@@ -629,7 +636,7 @@ struct HeatmapSurveyViewModelSurveyControlTests {
 
     @Test("startSurvey succeeds when calibrated")
     func startSurveySetsIsSurveying() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         vm.skipCalibration()
         vm.startSurvey()
@@ -638,7 +645,7 @@ struct HeatmapSurveyViewModelSurveyControlTests {
 
     @Test("stopSurvey sets isSurveying to false")
     func stopSurveyResetsFlag() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         vm.skipCalibration()
         vm.startSurvey()
@@ -648,19 +655,20 @@ struct HeatmapSurveyViewModelSurveyControlTests {
 
     @Test("takeMeasurement requires project and not already measuring")
     func takeMeasurementGuards() async {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         // No project, should be no-op
         await vm.takeMeasurement(at: CGPoint(x: 0.5, y: 0.5))
         #expect(vm.measurementPoints.isEmpty)
     }
 
-    @Test("takeMeasurement without service uses fallback with currentRSSI")
-    func takeMeasurementFallback() async {
-        let vm = HeatmapSurveyViewModel()
+    @Test("takeMeasurement appends point with values from the injected service")
+    func takeMeasurementUsesService() async {
+        let service = MockHeatmapService()
+        service.rssi = -55
+        service.ssid = "TestNet"
+        let vm = makeHeatmapVM(service: service)
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
         vm.skipCalibration()
-        vm.currentRSSI = -55
-        vm.currentSSID = "TestNet"
 
         await vm.takeMeasurement(at: CGPoint(x: 0.3, y: 0.7))
 
@@ -669,6 +677,7 @@ struct HeatmapSurveyViewModelSurveyControlTests {
         #expect(vm.measurementPoints[0].ssid == "TestNet")
         #expect(abs(vm.measurementPoints[0].floorPlanX - 0.3) < 0.001)
         #expect(abs(vm.measurementPoints[0].floorPlanY - 0.7) < 0.001)
+        #expect(service.measureCallCount == 1)
     }
 }
 
@@ -680,7 +689,7 @@ struct HeatmapSurveyViewModelSavedProjectsTests {
     @Test("listSavedProjects returns saved projects sorted by date")
     func listSavedProjectsReturnsSorted() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         vm.importFloorPlan(imageData: Data([1]), width: 100, height: 100)
 
         // Save two projects to the actual Documents dir (same as autoSave uses)
@@ -717,7 +726,7 @@ struct HeatmapSurveyViewModelBlueprintImportTests {
 
     @Test("importBlueprintProject sets isCalibrated to true")
     func importBlueprintSetsCalibrated() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
 
         let floor = BlueprintFloor(
             label: "Floor 1",
@@ -743,7 +752,7 @@ struct HeatmapSurveyViewModelBlueprintImportTests {
 
     @Test("importBlueprintProject with no floors sets error")
     func importBlueprintNoFloorsError() {
-        let vm = HeatmapSurveyViewModel()
+        let vm = makeHeatmapVM()
         let blueprint = BlueprintProject(
             name: "Empty",
             floors: [],
@@ -934,31 +943,16 @@ struct DeepLinkRouterTests {
 @MainActor
 struct HeatmapSurveyViewModelRegressionTests {
 
-    private func makeStubbedService(signalDBm: Int) -> IOSHeatmapService {
-        let wifi = MockWiFiInfoService()
-        wifi.currentWiFi = WiFiInfo(
-            ssid: "RegressionNet",
-            bssid: "11:22:33:44:55:66",
-            signalStrength: 80,
-            signalDBm: signalDBm,
-            channel: 6,
-            frequency: "2437 MHz",
-            band: .band2_4GHz,
-            noiseLevel: -90,
-            linkSpeed: 144.0
-        )
-        let speed = MockSpeedTestService()
-        speed.mockResult = SpeedTestData(downloadSpeed: 100, uploadSpeed: 50, latency: 15)
-        let ping = MockPingService()
-        return IOSHeatmapService(
-            wifiInfoService: wifi,
-            speedTestService: speed,
-            pingService: ping
-        )
+    private func makeStubService(signalDBm: Int) -> MockHeatmapService {
+        let service = MockHeatmapService()
+        service.rssi = signalDBm
+        service.ssid = "RegressionNet"
+        service.bssid = "11:22:33:44:55:66"
+        return service
     }
 
-    private func makeCalibratedVM() -> HeatmapSurveyViewModel {
-        let vm = HeatmapSurveyViewModel()
+    private func makeCalibratedVM(service: any HeatmapServiceProtocol) -> HeatmapSurveyViewModel {
+        let vm = makeHeatmapVM(service: service)
         vm.importFloorPlan(imageData: Data([1]), width: 1000, height: 500)
         vm.addCalibrationPoint(at: CGPoint.zero)
         vm.addCalibrationPoint(at: CGPoint(x: 100, y: 0))
@@ -966,39 +960,30 @@ struct HeatmapSurveyViewModelRegressionTests {
         return vm
     }
 
-    /// Regression guard for commit 6de9308 (heatmap IOSHeatmapService DI fix).
-    /// Before the fix, `heatmapService` was never injected and every measurement
-    /// silently returned the fallback -100 dBm sentinel. This test proves that
-    /// `configure(service:)` actually routes subsequent `takeMeasurement` calls
-    /// through the injected service.
-    @Test("configure(service:) routes takeMeasurement through the injected service")
-    func configureWiresServiceIntoTakeMeasurement() async {
-        let vm = makeCalibratedVM()
-
-        // Without service: fallback uses currentRSSI default (-100)
-        await vm.takeMeasurement(at: CGPoint(x: 0.1, y: 0.1))
-        let fallbackPoint = vm.measurementPoints.last
-        #expect(fallbackPoint?.rssi == -100)
-
-        // After configure: measurement uses the injected service's WiFiInfo
-        vm.configure(service: makeStubbedService(signalDBm: -45))
+    /// Regression guard for commits 6de9308 (DI fix) and #197 (god-class split).
+    /// Before 6de9308, `heatmapService` was never injected and every measurement
+    /// silently returned the fallback -100 dBm sentinel. P1.4 (#197) made the
+    /// service mandatory at init and deleted the fallback, so this test now
+    /// only verifies the happy path: a measurement reflects the service value.
+    @Test("takeMeasurement routes through the init-injected service")
+    func takeMeasurementUsesInjectedService() async {
+        let vm = makeCalibratedVM(service: makeStubService(signalDBm: -45))
         await vm.takeMeasurement(at: CGPoint(x: 0.2, y: 0.2))
-        let servicedPoint = vm.measurementPoints.last
-        #expect(servicedPoint?.rssi == -45)
+        #expect(vm.measurementPoints.last?.rssi == -45)
     }
 
-    /// Regression guard for commit 5266185 (shortcuts focus-thrash fix).
-    /// Before the fix, `startSurvey()` called `startSignalPolling()`, which
-    /// invoked the Shortcuts companion every 2s and stole focus back to the
-    /// Shortcuts app, making the survey tool unusable. The fix removed that
-    /// call. This test proves no background task auto-updates `currentRSSI`
-    /// after `startSurvey()` returns.
+    /// Regression guard for commit 5266185 (shortcuts focus-thrash fix) and
+    /// the P1.4 refactor that deleted `startSignalPolling()`/`pollInterval`
+    /// outright. Before 5266185, `startSurvey()` called `startSignalPolling()`,
+    /// which invoked the Shortcuts companion every 2s and stole focus back to
+    /// the Shortcuts app. P1.4 removed the polling code entirely. This test
+    /// proves no background task auto-updates `currentRSSI` after
+    /// `startSurvey()` returns.
     @Test("startSurvey does not start background signal polling")
     func startSurveyDoesNotStartSignalPolling() async {
-        let vm = makeCalibratedVM()
-        vm.configure(service: makeStubbedService(signalDBm: -45))
+        let vm = makeCalibratedVM(service: makeStubService(signalDBm: -45))
 
-        // Seed a sentinel the live-poll loop would overwrite on its first tick.
+        // Seed a sentinel an old live-poll loop would overwrite on its first tick.
         vm.currentRSSI = -77
 
         vm.startSurvey()

--- a/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/HeatmapSurveyViewModelTests.swift
@@ -702,7 +702,7 @@ struct HeatmapSurveyViewModelSavedProjectsTests {
 
         // Note: listSavedProjects reads from Documents, not temp.
         // This test verifies the function runs without crashing and returns an array.
-        let projects = HeatmapSurveyViewModel.listSavedProjects()
+        let projects = HeatmapFileManager.listSavedProjects()
         #expect(projects is [SavedSurveyInfo])
     }
 

--- a/Tests/NetMonitor-iOSTests/NetworkHealthScoreViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/NetworkHealthScoreViewModelTests.swift
@@ -9,6 +9,20 @@ import NetMonitorCore
 private final class MockNetworkHealthScoreService: NetworkHealthScoreServiceProtocol, @unchecked Sendable {
     var mockScore = NetworkHealthScore(score: 85, grade: "B", latencyMs: 25, packetLoss: 0.02, details: ["latency": "25 ms"])
     var calculateCallCount = 0
+    var updateCallCount = 0
+    var lastUpdate: (latencyMs: Double?, packetLoss: Double?, isConnected: Bool)?
+
+    func update(
+        latencyMs: Double?,
+        packetLoss: Double?,
+        dnsResponseMs: Double?,
+        deviceCount: Int?,
+        typicalDeviceCount: Int?,
+        isConnected: Bool
+    ) {
+        updateCallCount += 1
+        lastUpdate = (latencyMs, packetLoss, isConnected)
+    }
 
     func calculateScore() async -> NetworkHealthScore {
         calculateCallCount += 1
@@ -20,6 +34,15 @@ private final class MockNetworkHealthScoreService: NetworkHealthScoreServiceProt
 private final class SlowNetworkHealthScoreService: NetworkHealthScoreServiceProtocol, @unchecked Sendable {
     var mockScore = NetworkHealthScore(score: 85, grade: "B", latencyMs: 25, packetLoss: 0.02, details: [:])
     var calculateCallCount = 0
+
+    func update(
+        latencyMs: Double?,
+        packetLoss: Double?,
+        dnsResponseMs: Double?,
+        deviceCount: Int?,
+        typicalDeviceCount: Int?,
+        isConnected: Bool
+    ) {}
 
     func calculateScore() async -> NetworkHealthScore {
         calculateCallCount += 1

--- a/Tests/NetMonitor-iOSTests/iOSMockServices.swift
+++ b/Tests/NetMonitor-iOSTests/iOSMockServices.swift
@@ -282,3 +282,55 @@ final class MockMacConnectionService: MacConnectionServiceProtocol {
 
     func send(command: CommandPayload) async {}
 }
+
+// MARK: - Mock Heatmap Service
+
+/// Deterministic ``HeatmapServiceProtocol`` stub for ViewModel tests. Returns a
+/// `MeasurementPoint` echoing the requested coordinates with configurable
+/// `rssi` / `ssid` / `bssid` so tests can assert that the VM appended a point
+/// whose values came from the service rather than a fallback path.
+final class MockHeatmapService: HeatmapServiceProtocol, @unchecked Sendable {
+    var rssi: Int = -50
+    var ssid: String? = "MockNet"
+    var bssid: String? = nil
+    var downloadSpeed: Double?
+    var uploadSpeed: Double?
+    var latency: Double?
+
+    private(set) var measureCallCount = 0
+    private(set) var activeMeasureCallCount = 0
+    private(set) var lastCoordinates: (x: Double, y: Double)?
+
+    func takeMeasurement(at floorPlanX: Double, floorPlanY: Double) async -> MeasurementPoint {
+        measureCallCount += 1
+        lastCoordinates = (floorPlanX, floorPlanY)
+        return MeasurementPoint(
+            floorPlanX: floorPlanX,
+            floorPlanY: floorPlanY,
+            rssi: rssi,
+            ssid: ssid,
+            bssid: bssid
+        )
+    }
+
+    func takeActiveMeasurement(at floorPlanX: Double, floorPlanY: Double) async -> MeasurementPoint {
+        activeMeasureCallCount += 1
+        lastCoordinates = (floorPlanX, floorPlanY)
+        return MeasurementPoint(
+            floorPlanX: floorPlanX,
+            floorPlanY: floorPlanY,
+            rssi: rssi,
+            ssid: ssid,
+            bssid: bssid,
+            downloadSpeed: downloadSpeed,
+            uploadSpeed: uploadSpeed,
+            latency: latency
+        )
+    }
+
+    func startContinuousMeasurement(interval: TimeInterval) async -> AsyncStream<MeasurementPoint> {
+        AsyncStream { continuation in continuation.finish() }
+    }
+
+    func stopContinuousMeasurement() async {}
+}

--- a/Tests/NetMonitor-iOSTests/iOSMockServices.swift
+++ b/Tests/NetMonitor-iOSTests/iOSMockServices.swift
@@ -223,6 +223,7 @@ final class MockWiFiInfoService: WiFiInfoServiceProtocol, @unchecked Sendable {
 final class MockGatewayService: GatewayServiceProtocol {
     var gateway: GatewayInfo? = nil
     var isLoading: Bool = false
+    var latencyHistory: [Double] = []
     var detectCallCount = 0
 
     func detectGateway() async { detectCallCount += 1 }


### PR DESCRIPTION
## Summary

Lands the P1 items from the 2026-05-10 multi-agent arch review consensus. Six commits, five issues closed-on-merge, two issues deferred for product input.

| Item | Issue | Commit |
|---|---|---|
| WorldPingService data race | #198 | `f0eab23` |
| iOS App Intents return values + dialog | #199 | `1e79ec1` |
| DIP/LSP violations in 3 iOS ViewModels | #196 | `4b26ad7` |
| ConnectionBudget overrun + ping fanout cap | #194, #195 | `30fd109` |
| HeatmapSurveyViewModel split — Phase 1 (DI + dead code) | #197 | `388c981` |
| HeatmapSurveyViewModel split — Phase 2/3 (extract types) | #197 | `9d91ec4` |

## Highlights

**#198 — `WorldPingService.lastError` data race.** Mutable state behind `@unchecked Sendable` was unprotected. Now lock-guarded matching the `ThermalThrottleMonitor` pattern.

**#199 — iOS App Intents were no-ops.** `PingIntent`, `SpeedTestIntent`, `ScanNetworkIntent`, `NetworkStatusIntent` now return typed values (`ReturnsValue<Double>`/`<Int>`) with spoken dialog. `SaveWiFiReadingIntent` drops `nonisolated(unsafe) static var openAppWhenRun`. The 5-vs-4 shortcut count test moved to membership assertions.

**#196 — three concrete-type leaks fixed.** `GatewayServiceProtocol` gained `latencyHistory: [Double]`; `NetworkHealthScoreServiceProtocol` gained `update(...)`; `WiFiHeatmapViewModel` takes `any MacWiFiSignalProviding` (new local protocol). All three downcast call sites in ViewModels are gone — one test was literally asserting the broken downcast returns `[]`, flipped to a positive assertion.

**#194 + #195 — concurrency hardening pair.** `probePort` / `quickLatencyProbe` no longer release the budget in a detached `Task` (the overrun pattern). `measureDeviceLatencies` uses the sliding-window cap that `resolveDeviceNames` directly below it already had, throttled via `ThermalThrottleMonitor.effectiveLimit(from: 10)`.

**#197 — HeatmapSurveyViewModel god-class split, 714 → 543 LOC.**
- Phase 1 (`388c981`): `init(service:)` is now mandatory; `configure(service:)` and the `else` fallback in `takeMeasurement` (the actual bug surface from `6de9308`) deleted outright. All dead live-RSSI polling (`signalPollTask`, `pollInterval`, `startSignalPolling`, no-op `stopSignalPolling`) removed. `MockHeatmapService` added to `iOSMockServices.swift`; 70+ test sites batch-updated via a `makeHeatmapVM(service:)` factory.
- Phase 2/3 (`9d91ec4`): `HeatmapFileManager` (104 LOC) owns save/load/list/delete + autosave URL convention; `HeatmapExporter` (101 LOC) owns the composite UIImage render + share-sheet temp file.
- Phase 4 (`RoomScanCoordinator`): **not pursued** — calibration is intrinsically coupled to `surveyProject` mutation; documented as won't-do on #197.

## Deferred from the P1 list

- **#200 — Live Activities / widget extension.** Discovery: the entire `NetMonitor-iOS/Widget/` directory is `excludes: Widget/**` in `project.yml` and there is no widget-extension target in `pbxproj`. Needs a product decision (ship in v2.2 or delete ~700 LOC) before any code change makes sense. Comment on #200 has the details.

## Verification

- `swift build` clean for `NetMonitorCore` and `NetworkScanKit` on every commit.
- `swift test --filter ConnectionBudget` 8/8 pass.
- SwiftLint + SwiftFormat clean via pre-commit hook on every commit.
- iOS / macOS target compile + the full Swift Testing run still to be verified on the Mac mini node (gateway host can't sign / run XCUITests).

## Test plan

- [ ] `ssh mac-mini "cd ~/Projects/NetMonitor-2.0 && xcodebuild test -scheme NetMonitor-macOS -configuration Debug -destination 'platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:NetMonitor-macOSTests"`
- [ ] `ssh mac-mini "cd ~/Projects/NetMonitor-2.0 && xcodebuild test -scheme NetMonitor-iOS -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:NetMonitor-iOSTests"`
- [ ] Manual: iOS heatmap survey end-to-end (import floor plan → calibrate → take measurement → save → reload → export image + .netmonsurvey share-sheet).
- [ ] Manual: macOS scan a large network (200+ devices) and confirm no probe-budget overrun + no thermal throttle spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)