### PR TITLE
arch-review: P2 batch wave 1 (dead protocols, port-scan queue, SwiftData)

### DIFF
--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		00A471E0543C3A54E70BE0D1 /* WiFiReadingBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E608F81DA0D4B9CBDB79D37 /* WiFiReadingBridge.swift */; };
 		01308EAE3BB5C9D6174F9FC5 /* HeatmapCanvasNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5AAD4C5D0522533E686088 /* HeatmapCanvasNSView.swift */; };
 		01FB5C6201BA805E45FE9B0A /* ConnectivityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6D2120C3C1F97E4FB231D8 /* ConnectivityCard.swift */; };
+		0281A67F42E6230CC68B9CDF /* SchemaMigrationPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6392CA5B0C8107207EFCED6 /* SchemaMigrationPlan.swift */; };
 		02E54AEEFC82F6E9746AA53B /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7663D6B71E58A8F1302100 /* FlowLayout.swift */; };
 		02F1D11D8040B5ABE82A311B /* GatewayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ECEB0143FB17F5EE8C4EB4 /* GatewayService.swift */; };
 		0339F8A0415336098C06AF55 /* ConnectionSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA713685A5D01F84A2D34A6 /* ConnectionSettingsSection.swift */; };
@@ -287,7 +288,9 @@
 		A0DD64005F822FD5D162A826 /* NetworkDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50ECF7BAE5CF934F596DE1 /* NetworkDetailViewTests.swift */; };
 		A12A2FCB6ED9AAE4E43A361C /* AddNetworkSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F5FE876022BF83E2244721 /* AddNetworkSheet.swift */; };
 		A19017FAD45462168EAB7157 /* TimelineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47384CC91538ECC29ED7E22C /* TimelineUITests.swift */; };
+		A28955B327782AFDC8BEE99F /* RoomPlanScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93FCD8E5A7FA84E3E062053 /* RoomPlanScanViewController.swift */; };
 		A3C28A07E64331FB2BA6BEE7 /* ScheduledScanSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9B7FBD1F07CF6425DC114A /* ScheduledScanSettingsView.swift */; };
+		A4A7A4B2DE9D49BFB584198B /* HeatmapFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FCAD51E87A57B8106A76CD /* HeatmapFileManager.swift */; };
 		A5722676B309E4D7FDB7BF60 /* WHOISServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC3E1DEFE0846C19ABCF548 /* WHOISServiceTests.swift */; };
 		A8D65DDFD2B7DE5CBD3E95D8 /* MacConnectionServiceReceiveBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD6C6F1D69669E8BECE28CF /* MacConnectionServiceReceiveBufferTests.swift */; };
 		A92A696C11AA80562AE217A1 /* SettingsFunctionalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1428BB9BB443F390D8405C03 /* SettingsFunctionalUITests.swift */; };
@@ -378,6 +381,7 @@
 		DD9702E4A201DEC52A645FE6 /* UptimeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926AB2C0DCBFD54EFD5480B8 /* UptimeViewModel.swift */; };
 		DDB9CB792F522B464C563C42 /* BackgroundTaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF59316A7FACA0F164BBDD46 /* BackgroundTaskService.swift */; };
 		DE52B8ABF0A9D8D6390D3456 /* WiFiHeatmapViewModelExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EEF66329B8A2875D465BDB /* WiFiHeatmapViewModelExportTests.swift */; };
+		DE695BF79550E7EAC39FF8A7 /* HeatmapExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697FD6AA545E38F7DFD1F806 /* HeatmapExporter.swift */; };
 		DE74F6B78A2FAC90C87FB084 /* SettingsPersistenceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5B8FA3615567C2D430F676 /* SettingsPersistenceUITests.swift */; };
 		DF6BC00231E6C72864EAEB70 /* TracerouteToolUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B066F0CD9CFC336ED86D3E /* TracerouteToolUITests.swift */; };
 		DFBBF93D85E9038D8B07E5EE /* EventListenerServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F566B193A0894428EF6E3382 /* EventListenerServiceTests.swift */; };
@@ -641,9 +645,11 @@
 		6321E1A30E4AEF89B9C9F4BE /* SpeedTestToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestToolUITests.swift; sourceTree = "<group>"; };
 		65DD482FB958FC0A76B656CE /* PingToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingToolViewModel.swift; sourceTree = "<group>"; };
 		66EEF66329B8A2875D465BDB /* WiFiHeatmapViewModelExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModelExportTests.swift; sourceTree = "<group>"; };
+		66FCAD51E87A57B8106A76CD /* HeatmapFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapFileManager.swift; sourceTree = "<group>"; };
 		673FFB780C1777738E437731 /* RoomPlanScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPlanScannerViewModel.swift; sourceTree = "<group>"; };
 		674DF2A6E73DEA21A751E2A6 /* SettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITests.swift; sourceTree = "<group>"; };
 		6791657706821C08F331AB13 /* HeatmapSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapSurveyViewModel.swift; sourceTree = "<group>"; };
+		697FD6AA545E38F7DFD1F806 /* HeatmapExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapExporter.swift; sourceTree = "<group>"; };
 		6A3C5A26C422CE3455CD55A3 /* TimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineView.swift; sourceTree = "<group>"; };
 		6AC7F633EA592CA1A5D2F95C /* CompanionMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionMessageHandlerTests.swift; sourceTree = "<group>"; };
 		6B192A3420B4F00F8DFB10D8 /* DNSLookupToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSLookupToolUITests.swift; sourceTree = "<group>"; };
@@ -751,6 +757,7 @@
 		A7191F3156FFC451BBDAA904 /* DefaultTargetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTargetsProvider.swift; sourceTree = "<group>"; };
 		A76DD42C0ACB3B6EC149A66C /* WiFiHeatmapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModel.swift; sourceTree = "<group>"; };
 		A8B4635DD799E78E2C32767D /* WiFiHeatmapViewModelSaveLoadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModelSaveLoadTests.swift; sourceTree = "<group>"; };
+		A93FCD8E5A7FA84E3E062053 /* RoomPlanScanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPlanScanViewController.swift; sourceTree = "<group>"; };
 		A980FAAF1EB5E1BBEF24816A /* ICMPMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICMPMonitorServiceTests.swift; sourceTree = "<group>"; };
 		AAE65435D045DE3913F261E2 /* MacConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacConnectionServiceTests.swift; sourceTree = "<group>"; };
 		ABFB99B16D29E2338B306CA9 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
@@ -795,6 +802,7 @@
 		C48B63C3B6047CA905960844 /* TargetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetsView.swift; sourceTree = "<group>"; };
 		C4E17B0FBE23722518BB7D7B /* TargetStatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetStatisticsView.swift; sourceTree = "<group>"; };
 		C5BC316F3DB96C6B180E0814 /* BonjourDiscoveryToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourDiscoveryToolViewModel.swift; sourceTree = "<group>"; };
+		C6392CA5B0C8107207EFCED6 /* SchemaMigrationPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaMigrationPlan.swift; sourceTree = "<group>"; };
 		C6CBE58C2938DC79DF670A35 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		C6FE541A23CE7784745B9EBA /* ProModeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProModeRowView.swift; sourceTree = "<group>"; };
 		C78A2017DEA3D9CD49AFEC03 /* SidebarFunctionalUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarFunctionalUITests.swift; sourceTree = "<group>"; };
@@ -991,6 +999,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		10AA99B050E34F49E41D2A79 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				C6392CA5B0C8107207EFCED6 /* SchemaMigrationPlan.swift */,
+			);
+			path = Persistence;
+			sourceTree = "<group>";
+		};
 		10E4CCBCC6C445B127309731 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -1037,6 +1053,8 @@
 				11ECEB0143FB17F5EE8C4EB4 /* GatewayService.swift */,
 				DDEDB32CF47D675F61CF5563 /* GeoFenceManager.swift */,
 				431FA615915AAEDF20F196DC /* GlassCard.swift */,
+				697FD6AA545E38F7DFD1F806 /* HeatmapExporter.swift */,
+				66FCAD51E87A57B8106A76CD /* HeatmapFileManager.swift */,
 				B4C66593DA429DA1FB792D1B /* IOSHeatmapService.swift */,
 				ABFB99B16D29E2338B306CA9 /* LiveActivityManager.swift */,
 				51478B9F5A8A7517976C7AFA /* Logging.swift */,
@@ -1207,6 +1225,7 @@
 				207F5A4C57A503A97B48F7D9 /* HeatmapSidebarSheet.swift */,
 				8EE6DAA8D618B3A85832866F /* HeatmapSurveyView.swift */,
 				0B11D2E300E8D181366B7D24 /* RoomPlanScannerView.swift */,
+				A93FCD8E5A7FA84E3E062053 /* RoomPlanScanViewController.swift */,
 				3BAC12710A5E5E5F99A1F12D /* WiFiShortcutSetupView.swift */,
 			);
 			path = Heatmap;
@@ -1500,6 +1519,7 @@
 			children = (
 				D1264DF84316245CAF09F833 /* App */,
 				87DBFB32E1330098799857E3 /* MenuBar */,
+				10AA99B050E34F49E41D2A79 /* Persistence */,
 				911A63FF886A2DF3CD7FD6B3 /* Platform */,
 				A2DE8DFED425243FF30F8905 /* Preview */,
 				15D3E6CBB4D81C39C3076E2A /* Resources */,
@@ -2024,6 +2044,7 @@
 				7C15E30650A9210433ED8208 /* QuickJumpSheet.swift in Sources */,
 				70926F040D08693ACF1B16B9 /* RateAppService.swift in Sources */,
 				7D9483D8831B8A58460A4154 /* SSLCertificateMonitorView.swift in Sources */,
+				0281A67F42E6230CC68B9CDF /* SchemaMigrationPlan.swift in Sources */,
 				3DCD3D682BC9AEF8B4C0AA09 /* SchemaV1.swift in Sources */,
 				E21F3C1C933FB5E391921523 /* SettingsView.swift in Sources */,
 				5B741E94E2272DCF651DA501 /* ShellCommandRunner.swift in Sources */,
@@ -2170,6 +2191,8 @@
 				07AC9FAE35CF72270CED8F2B /* GlassCard.swift in Sources */,
 				6AECEC66F4DA85EC8EDDB36D /* HeatmapCalibrationSheet.swift in Sources */,
 				5818D0D98146932BBE66DB10 /* HeatmapCanvasView.swift in Sources */,
+				DE695BF79550E7EAC39FF8A7 /* HeatmapExporter.swift in Sources */,
+				A4A7A4B2DE9D49BFB584198B /* HeatmapFileManager.swift in Sources */,
 				6F3BB4AE74315FC6A865640B /* HeatmapProjectsView.swift in Sources */,
 				4604FF1A5966EFBD1C2F7190 /* HeatmapSidebarSheet.swift in Sources */,
 				CEFD08671D1E06FEBD714AD1 /* HeatmapSurveyView.swift in Sources */,
@@ -2197,6 +2220,7 @@
 				39530BBB571E24F123543EC2 /* PublicIPService.swift in Sources */,
 				C22CD2C4F138EBB88F30000B /* RateAppService.swift in Sources */,
 				F4574FC8446A592B70216304 /* RoomPlanGeometryAdapter.swift in Sources */,
+				A28955B327782AFDC8BEE99F /* RoomPlanScanViewController.swift in Sources */,
 				9FF67532537334ABC04E0870 /* RoomPlanScannerView.swift in Sources */,
 				793535846969E935A13718D6 /* RoomPlanScannerViewModel.swift in Sources */,
 				C93350DC36F292072A92CAB8 /* RoomPlanTaskTimeout.swift in Sources */,

--- a/NetMonitor-macOS/App/NetMonitorApp.swift
+++ b/NetMonitor-macOS/App/NetMonitorApp.swift
@@ -59,12 +59,20 @@ struct NetMonitorApp: App {
 
         do {
             // launch-time "Duplicate version checksums detected" exception.
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: NetMonitorMigrationPlan.self,
+                configurations: [modelConfiguration]
+            )
         } catch {
             Logger.app.warning("Could not create persistent ModelContainer: \(error)")
             do {
                 let inMemoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-                return try ModelContainer(for: schema, configurations: [inMemoryConfig])
+                return try ModelContainer(
+                    for: schema,
+                    migrationPlan: NetMonitorMigrationPlan.self,
+                    configurations: [inMemoryConfig]
+                )
             } catch {
                 fatalError("Could not create in-memory ModelContainer: \(error)")
             }

--- a/NetMonitor-macOS/Persistence/SchemaMigrationPlan.swift
+++ b/NetMonitor-macOS/Persistence/SchemaMigrationPlan.swift
@@ -1,0 +1,25 @@
+import SwiftData
+
+/// SwiftData migration plan for the NetMonitor macOS app.
+///
+/// The current persisted schema is `SchemaV1` (defined in `App/SchemaV1.swift`).
+/// No migration stages exist yet — v1 has no predecessor.
+///
+/// When the next versioned schema lands (e.g. `SchemaV2`):
+/// 1. Append it to `schemas`.
+/// 2. Add a `MigrationStage.lightweight(...)` or `.custom(...)` entry to `stages`
+///    describing the transition from the previous version.
+///
+/// Passing this plan to `ModelContainer(for:migrationPlan:configurations:)` makes
+/// future non-additive schema changes explicit instead of silently relying on
+/// SwiftData's lightweight-migration fallback (which crashes on destructive
+/// changes such as renamed or removed properties).
+enum NetMonitorMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self]
+    }
+
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -397,10 +397,19 @@ final class DeviceDiscoveryCoordinator {
         loadPersistedDevices(for: profileID)
     }
 
+    /// Shared concurrent queue for `checkPort` so each TCP probe doesn't allocate a
+    /// fresh `DispatchQueue`. Concurrent attribute preserves parallel fan-out across
+    /// ports/devices (15 ports x N devices were previously running on N*15 disposable
+    /// queues per scan). See #203.
+    private static let portScanQueue = DispatchQueue(
+        label: "com.netmonitor.quickportscan",
+        attributes: .concurrent
+    )
+
     /// Non-blocking TCP connect check with configurable timeout.
     private static func checkPort(host: String, port: Int, timeoutMs: Int32) async -> Bool {
         await withCheckedContinuation { continuation in
-            DispatchQueue(label: "com.netmonitor.quickportscan").async {
+            portScanQueue.async {
                 var hints = addrinfo()
                 hints.ai_family = AF_INET
                 hints.ai_socktype = SOCK_STREAM

--- a/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
+++ b/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
@@ -15,7 +15,17 @@ struct QuickJumpSheet: View {
     @Binding var isPresented: Bool
 
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. Search displays `prefix(8)`,
+    /// so 500 most-recent rows is more than enough working set.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var searchText: String = ""
     @FocusState private var isFocused: Bool

--- a/NetMonitor-macOS/Views/DevicesView.swift
+++ b/NetMonitor-macOS/Views/DevicesView.swift
@@ -13,7 +13,17 @@ struct DevicesView: View {
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table; 500 most-recent devices is
+    /// well above any realistic active-network size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var selectedDevice: LocalDevice?
     @State private var searchText: String = ""

--- a/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
+++ b/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
@@ -8,7 +8,17 @@ struct NetworkDevicesPanel: View {
     let networkProfileID: UUID?
 
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var allDevices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var allDevices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. View further filters by
+    /// `networkProfileID`; 500 most-recent devices is well above active-network size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var searchText: String = ""
     @AppStorage("netmonitor.devicesPanel.sortOrder") private var sortOrder: PanelSortOrder = .ipAddress

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -16,7 +16,17 @@ struct SidebarView: View {
     // periphery:ignore
     @Environment(MonitoringSession.self) private var monitoringSession: MonitoringSession?
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table — sidebar only needs counts
+    /// per profile, and 500 most-recent devices comfortably covers active networks.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     private var headerText: Color {
         colorScheme == .dark ? .white : Color(red: 51/255, green: 65/255, blue: 85/255)

--- a/NetMonitor-macOS/Views/TargetStatisticsView.swift
+++ b/NetMonitor-macOS/Views/TargetStatisticsView.swift
@@ -12,17 +12,16 @@ struct TargetStatisticsView: View {
     init(target: NetworkTarget) {
         self.target = target
 
-        // Query last 50 measurements for this target
         let targetID = target.id
-        let predicate = #Predicate<TargetMeasurement> { measurement in
-            measurement.target?.id == targetID
-        }
-
-        _measurements = Query(
-            filter: predicate,
-            sort: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)],
-            animation: .default
+        var descriptor = FetchDescriptor<TargetMeasurement>(
+            predicate: #Predicate<TargetMeasurement> { measurement in
+                measurement.target?.id == targetID
+            },
+            sortBy: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)]
         )
+        // Protective cap — TargetMeasurement is the largest growing table.
+        descriptor.fetchLimit = 5000
+        _measurements = Query(descriptor, animation: .default)
     }
 
     var body: some View {

--- a/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
@@ -10,7 +10,17 @@ import NetMonitorCore
 import SwiftData
 
 struct WakeOnLanToolView: View {
-    @Query private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. View further filters to
+    /// devices with MAC addresses; 500 most-recent is well above realistic size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var selectedDeviceID: UUID?
     @State private var macAddress = ""

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
@@ -329,11 +329,6 @@ public struct ScanDiff: Sendable {
 
 // MARK: - New Feature Service Protocols
 
-/// Protocol for subnet calculation.
-public protocol SubnetCalculatorServiceProtocol: AnyObject, Sendable {
-    func calculate(cidr: String) -> SubnetInfo?
-}
-
 /// Protocol for world ping (global latency checks via external API).
 public protocol WorldPingServiceProtocol: AnyObject, Sendable {
     var lastError: String? { get }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/TracerouteService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/TracerouteService.swift
@@ -19,7 +19,7 @@ public actor TracerouteService: TracerouteServiceProtocol {
 
     // MARK: - State
 
-    private var isRunning = false
+    public private(set) var isRunning = false
 
     // MARK: - Initialization
 
@@ -56,11 +56,6 @@ public actor TracerouteService: TracerouteServiceProtocol {
     /// Stops the current traceroute operation.
     public func stop() async {
         isRunning = false
-    }
-
-    /// Returns whether a traceroute is currently running.
-    public var running: Bool {
-        isRunning
     }
 
     // MARK: - Private Implementation

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceIntegrationTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceIntegrationTests.swift
@@ -113,7 +113,7 @@ struct TracerouteServiceIntegrationTests {
         #expect(count >= 1, "Stream must have yielded at least one hop before stop()")
 
         // Verify the service is no longer running
-        let isRunning = await service.running
+        let isRunning = await service.isRunning
         #expect(isRunning == false, "Service must not be in running state after stop()")
     }
 
@@ -123,7 +123,7 @@ struct TracerouteServiceIntegrationTests {
         for await _ in await service.trace(host: "127.0.0.1", maxHops: 1, timeout: 3.0) {
             // consume all hops
         }
-        let isRunning = await service.running
+        let isRunning = await service.isRunning
         #expect(isRunning == false, "running must be false after the stream finishes naturally")
     }
 

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceTests.swift
@@ -104,10 +104,10 @@ struct TracerouteServiceTests {
 
     // MARK: - Initial state
 
-    @Test("running is false before any trace")
+    @Test("isRunning is false before any trace")
     func runningIsFalseBeforeAnyTrace() async {
         let service = TracerouteService()
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false)
     }
 
@@ -118,7 +118,7 @@ struct TracerouteServiceTests {
         let service = TracerouteService()
         await service.stop()
         await service.stop()
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false)
     }
 

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanContext.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanContext.swift
@@ -11,9 +11,6 @@ public struct ScanContext: Sendable {
     /// The local device's IP address (excluded from probing).
     public let localIP: String?
 
-    /// The network profile associated with this scan.
-    public let networkProfile: NetworkScanProfile?
-
     /// The scan strategy determining which phases are included.
     public let scanStrategy: ScanStrategy
 
@@ -21,13 +18,11 @@ public struct ScanContext: Sendable {
         hosts: [String],
         subnetFilter: @escaping @Sendable (String) -> Bool,
         localIP: String?,
-        networkProfile: NetworkScanProfile? = nil,
         scanStrategy: ScanStrategy = .full
     ) {
         self.hosts = hosts
         self.subnetFilter = subnetFilter
         self.localIP = localIP
-        self.networkProfile = networkProfile
         self.scanStrategy = scanStrategy
     }
 }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanContextTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanContextTests.swift
@@ -45,27 +45,7 @@ struct ScanContextTests {
         #expect(ctx.subnetFilter("192.168.1.1") == false)
     }
 
-    // MARK: - NetworkProfile and ScanStrategy
-
-    @Test("networkProfile defaults to nil")
-    func networkProfileDefaultsToNil() {
-        let ctx = ScanContext(hosts: [], subnetFilter: { _ in true }, localIP: nil)
-        #expect(ctx.networkProfile == nil)
-    }
-
-    @Test("networkProfile is stored when provided")
-    func networkProfileStored() {
-        let profile = NetworkScanProfile(id: "home-5ghz", name: "Home 5GHz", subnetCIDR: "192.168.1.0/24")
-        let ctx = ScanContext(
-            hosts: [],
-            subnetFilter: { _ in true },
-            localIP: nil,
-            networkProfile: profile
-        )
-        #expect(ctx.networkProfile?.id == "home-5ghz")
-        #expect(ctx.networkProfile?.name == "Home 5GHz")
-        #expect(ctx.networkProfile?.subnetCIDR == "192.168.1.0/24")
-    }
+    // MARK: - ScanStrategy
 
     @Test("scanStrategy defaults to .full")
     func scanStrategyDefaultsToFull() {
@@ -97,19 +77,16 @@ struct ScanContextTests {
 
     @Test("full context with all parameters")
     func fullContext() {
-        let profile = NetworkScanProfile(id: "office", name: "Office Network")
         let ctx = ScanContext(
             hosts: ["10.0.0.1"],
             subnetFilter: { ip in ip.hasPrefix("10.0.") },
             localIP: "10.0.0.50",
-            networkProfile: profile,
             scanStrategy: .remote
         )
 
         #expect(ctx.hosts == ["10.0.0.1"])
         #expect(ctx.subnetFilter("10.0.0.1") == true)
         #expect(ctx.localIP == "10.0.0.50")
-        #expect(ctx.networkProfile?.id == "office")
         #expect(ctx.scanStrategy == .remote)
     }
 }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanStrategyCoverageTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanStrategyCoverageTests.swift
@@ -134,25 +134,22 @@ struct ScanStrategyCoverageTests {
         #expect(closure().id == "s")
     }
 
-    // MARK: - ScanContext with NetworkScanProfile and ScanStrategy
+    // MARK: - ScanContext with ScanStrategy
 
-    @Test("ScanContext with .remote strategy and profile")
-    func contextWithRemoteStrategyAndProfile() {
-        let profile = NetworkScanProfile(id: "remote-office", name: "Remote Office", subnetCIDR: "10.10.0.0/16")
+    @Test("ScanContext with .remote strategy")
+    func contextWithRemoteStrategy() {
         let ctx = ScanContext(
             hosts: ["10.10.0.1"],
             subnetFilter: { _ in true },
             localIP: nil,
-            networkProfile: profile,
             scanStrategy: .remote
         )
         #expect(ctx.scanStrategy == .remote)
-        #expect(ctx.networkProfile?.id == "remote-office")
-        #expect(ctx.networkProfile?.subnetCIDR == "10.10.0.0/16")
+        #expect(ctx.hosts == ["10.10.0.1"])
     }
 
-    @Test("ScanContext with .full strategy and nil profile")
-    func contextWithFullStrategyNilProfile() {
+    @Test("ScanContext with .full strategy")
+    func contextWithFullStrategy() {
         let ctx = ScanContext(
             hosts: [],
             subnetFilter: { _ in true },
@@ -160,7 +157,6 @@ struct ScanStrategyCoverageTests {
             scanStrategy: .full
         )
         #expect(ctx.scanStrategy == .full)
-        #expect(ctx.networkProfile == nil)
         #expect(ctx.localIP == "192.168.1.100")
     }
 

--- a/Tests/NetMonitor-macOSTests/TracerouteServiceErrorSurfacingTests.swift
+++ b/Tests/NetMonitor-macOSTests/TracerouteServiceErrorSurfacingTests.swift
@@ -59,7 +59,7 @@ struct TracerouteServiceErrorSurfacingTests {
         // Consume the stream
         for await _ in stream {}
 
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "running should be false after trace completes")
     }
 
@@ -74,7 +74,7 @@ struct TracerouteServiceErrorSurfacingTests {
         // Drain remaining items
         for await _ in stream {}
 
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "Service should not be stuck in running state after stop()")
     }
 
@@ -105,7 +105,7 @@ struct TracerouteServiceErrorSurfacingTests {
 
         // localhost trace should complete (either with hops or timeout) — not hang forever.
         // The key assertion is that we reach this point (stream finishes).
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "Trace to localhost should complete and set running to false")
     }
 }


### PR DESCRIPTION
## Summary

Four well-isolated P2 items from the 2026-05-10 arch review consensus, implemented in parallel via 4 worktree-isolated agents and bundled here. Files are disjoint by design — no cross-ticket conflict during cherry-pick.

| Item | Issue | Bundled SHA | Original branch |
|---|---|---|---|
| Delete 3 dead protocols/types | #204 | `7a6ea0d` | `arch-review/p2-4-dead-protocols` |
| Reuse shared GCD queue in port scan | #203 | `ee61baf` | `arch-review/p2-3-portscan-queue` |
| Cap unbounded `@Query` with `fetchLimit` | #207 | `ec0ad19` | `arch-review/p2-7-fetchlimit` |
| Scaffold `SchemaMigrationPlan` | #208 | `30c1017` | `arch-review/p2-8-schema-migration` |

## Highlights

**#204 — 3 surgical deletes, +16 / -58 LOC across 8 files.**
- `SubnetCalculatorServiceProtocol` (Core) — zero conformers.
- `ScanContext.networkProfile` (NetworkScanKit) — unused stored property + init arg; 2 round-trip tests removed, 2 others lost an arg.
- `TracerouteService.running` public alias — promoted `private isRunning` to `public private(set)` and updated 7 test references.
- Preserved `DeviceNameResolverProtocol` (live DI seam) and `SubnetInfo` (live in subnet calculator) after consensus's "possibly relevant" callouts.

**#203 — eliminate per-call GCD-queue allocation in quick port scan.**
- `DeviceDiscoveryCoordinator.checkPort` allocated a fresh `DispatchQueue(label:)` inside every `withCheckedContinuation`. On a typical quick scan that's 150+ disposable GCD queues.
- Replaced with a file-scope `static let portScanQueue = DispatchQueue(label: ..., attributes: .concurrent)`. The `.concurrent` attribute is load-bearing — a serial queue would have serialised every TCP probe through its 1000ms timeout.

**#207 — protective `fetchLimit` on 6 growing `@Query` sites.**
- All 6 `@Model: LocalDevice` queries on macOS now cap at 500 (`SidebarView`, `NetworkDevicesPanel`, `DevicesView`, `QuickJumpSheet`, `WakeOnLanToolView`).
- `TargetStatisticsView`'s `TargetMeasurement` query caps at 5000 (≈14 days of 5-min samples — stats remain meaningful).
- Skipped 2 `NetworkTarget` queries — user-managed, bounded by definition.
- Pattern: per-view `private static func descriptor() -> FetchDescriptor<T>` returning a configured descriptor.
- Caveat from agent: `SidebarView` filters across profiles to count badges; under-counting is possible for less-active profiles past 500 total devices. Acceptable trade-off at current realistic scale.

**#208 — scaffold-only schema versioning, no migrations yet.**
- New file `NetMonitor-macOS/Persistence/SchemaMigrationPlan.swift`.
- `NetMonitorMigrationPlan: SchemaMigrationPlan` referencing the existing `SchemaV1` (which already enumerates `NetworkTarget`, `TargetMeasurement`, `LocalDevice`, `SessionRecord`, `ConnectivityRecord`).
- `stages: []` for v1 (no predecessor). Future schema changes have a place to land.
- Both `ModelContainer` call sites in `NetMonitorApp.swift` (primary + in-memory fallback) now pass `migrationPlan: NetMonitorMigrationPlan.self`. Preview / test containers untouched.

## What was deferred from P2

Remaining P2 items (#201, #202, #205, #206, #209, #210, #211) need a second wave — they either cross-cut too many files for safe parallel work (P2.9 iOS composition root, P2.11 NavigationStack routing) or have file overlap with this batch (P2.6 adds `Sendable` to the same `ServiceProtocols.swift` this batch deletes from).

## Verification

- `swift build` clean for `NetMonitorCore` and `NetworkScanKit` after all 4 commits applied in sequence.
- `swift test --filter ConnectionBudget` 8/8 pass (regression guard for #194 still green).
- `swift test --filter ScanPipeline` 46/46 pass per the originating P2.3 agent.
- macOS `xcodebuild build` succeeded per the originating P2.7 / P2.8 agents.
- SwiftLint + SwiftFormat clean via pre-commit hook on each originating commit.
- iOS target compile + full Swift Testing run still needs Mac mini verification.

## Test plan

- [ ] `ssh mac-mini "cd ~/Projects/NetMonitor-2.0 && xcodebuild test -scheme NetMonitor-macOS -configuration Debug -destination 'platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:NetMonitor-macOSTests"`
- [ ] `ssh mac-mini "cd ~/Projects/NetMonitor-2.0 && xcodebuild test -scheme NetMonitor-iOS -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:NetMonitor-iOSTests"`
- [ ] Manual: macOS scan of a >500-device network — verify badge counts on `SidebarView` are still useful and the device list doesn't drop visible rows (the cap is at the model layer; if a UX issue appears here, raise the cap or paginate).
- [ ] Manual: macOS launch — verify `ModelContainer` opens cleanly (no SchemaV1 mismatch errors); existing SwiftData stores should load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)