### PR TITLE
arch-review: composition root + value-based nav + WorldPingRunner (#202 partial, #209, #211)

### DIFF
--- a/NetMonitor-iOS/App/AppEnvironment.swift
+++ b/NetMonitor-iOS/App/AppEnvironment.swift
@@ -1,0 +1,85 @@
+import Foundation
+import NetMonitorCore
+
+// MARK: - AppEnvironment
+
+/// Composition root for the iOS target. Holds references to the foundational
+/// services that root ViewModels depend on so they can be wired explicitly
+/// from `@main` instead of via scattered `Service.shared` defaults inside VM
+/// init signatures.
+///
+/// **Migration pattern.** Root views read this from `@Environment`:
+/// ```swift
+/// @Environment(AppEnvironment.self) private var env
+/// @State private var viewModel: DashboardViewModel
+/// init(env: AppEnvironment) {
+///     _viewModel = State(initialValue: DashboardViewModel(
+///         networkMonitor: env.networkMonitor,
+///         deviceDiscoveryService: env.deviceDiscovery,
+///         ...
+///     ))
+/// }
+/// ```
+///
+/// VM init signatures keep their existing `Service.shared` defaults during the
+/// migration so tests and child views aren't broken. Once every root view is
+/// migrated, those defaults can be removed in a follow-up.
+@MainActor
+@Observable
+final class AppEnvironment {
+
+    // MARK: - Services
+
+    let networkMonitor: any NetworkMonitorServiceProtocol
+    let deviceDiscovery: any DeviceDiscoveryServiceProtocol
+    let macConnection: any MacConnectionServiceProtocol
+    let publicIP: any PublicIPServiceProtocol
+    let wifiInfo: any WiFiInfoServiceProtocol
+    let targetManager: TargetManager
+    let activityLog: ToolActivityLog
+    let eventService: NetworkEventService
+    let scanScheduler: any ScanSchedulerServiceProtocol
+
+    // MARK: - Init
+
+    init(
+        networkMonitor: any NetworkMonitorServiceProtocol,
+        deviceDiscovery: any DeviceDiscoveryServiceProtocol,
+        macConnection: any MacConnectionServiceProtocol,
+        publicIP: any PublicIPServiceProtocol,
+        wifiInfo: any WiFiInfoServiceProtocol,
+        targetManager: TargetManager,
+        activityLog: ToolActivityLog,
+        eventService: NetworkEventService,
+        scanScheduler: any ScanSchedulerServiceProtocol
+    ) {
+        self.networkMonitor = networkMonitor
+        self.deviceDiscovery = deviceDiscovery
+        self.macConnection = macConnection
+        self.publicIP = publicIP
+        self.wifiInfo = wifiInfo
+        self.targetManager = targetManager
+        self.activityLog = activityLog
+        self.eventService = eventService
+        self.scanScheduler = scanScheduler
+    }
+
+    // MARK: - Factories
+
+    /// Production wiring. Uses the existing `*.shared` instances so services
+    /// shared with `@main` lifecycle hooks (`EventListenerService`,
+    /// `BackgroundTaskService`, etc.) keep observing the same state.
+    static func live() -> AppEnvironment {
+        AppEnvironment(
+            networkMonitor: NetworkMonitorService.shared,
+            deviceDiscovery: DeviceDiscoveryService.shared,
+            macConnection: MacConnectionService.shared,
+            publicIP: PublicIPService(),
+            wifiInfo: WiFiInfoService(),
+            targetManager: TargetManager.shared,
+            activityLog: ToolActivityLog.shared,
+            eventService: NetworkEventService.shared,
+            scanScheduler: ScanSchedulerService.shared
+        )
+    }
+}

--- a/NetMonitor-iOS/App/NetmonitorApp.swift
+++ b/NetMonitor-iOS/App/NetmonitorApp.swift
@@ -10,6 +10,7 @@ struct NetmonitorApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var showOnboarding = false
     @State private var deepLinkRouter = DeepLinkRouter()
+    @State private var environment: AppEnvironment = .live()
 
     private static var isUITesting: Bool {
         let args = ProcessInfo.processInfo.arguments
@@ -62,6 +63,7 @@ struct NetmonitorApp: App {
             ContentView()
                 .preferredColorScheme(resolvedColorScheme)
                 .accessibilityIdentifier("screen_main")
+                .environment(environment)
                 .environment(deepLinkRouter)
                 .onOpenURL { url in
                     deepLinkRouter.handle(url: url)

--- a/NetMonitor-iOS/Navigation/AppDestination.swift
+++ b/NetMonitor-iOS/Navigation/AppDestination.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+// MARK: - AppDestination
+
+/// Typed navigation destinations for the iOS app's `NavigationStack` hierarchy.
+///
+/// Standardizes value-based routing across the Dashboard, Devices, and
+/// Network Map tabs. Adding a new destination is a four-step process:
+/// 1. Add a case here.
+/// 2. Add the corresponding `case` in ``AppDestinationModifier``.
+/// 3. Replace the legacy `NavigationLink(destination:)` at the call site with
+///    `NavigationLink(value: AppDestination.<case>)`.
+/// 4. Make sure the originating `NavigationStack` has `.appDestinations()`
+///    installed on its root content.
+enum AppDestination: Hashable {
+    case deviceDetail(ipAddress: String)
+    case ping(host: String)
+    case portScanner(host: String)
+    case dnsLookup(domain: String)
+    case wakeOnLAN(mac: String)
+    case speedTest
+    case heatmapSurvey
+}
+
+// MARK: - View Modifier
+
+private struct AppDestinationModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.navigationDestination(for: AppDestination.self) { destination in
+            switch destination {
+            case .deviceDetail(let ip):
+                DeviceDetailView(ipAddress: ip)
+            case .ping(let host):
+                PingToolView(initialHost: host)
+            case .portScanner(let host):
+                PortScannerToolView(initialHost: host)
+            case .dnsLookup(let domain):
+                DNSLookupToolView(initialDomain: domain)
+            case .wakeOnLAN(let mac):
+                WakeOnLANToolView(initialMacAddress: mac)
+            case .speedTest:
+                SpeedTestToolView()
+            case .heatmapSurvey:
+                HeatmapSurveyView()
+            }
+        }
+    }
+}
+
+extension View {
+    /// Registers the canonical ``AppDestination`` map on this view's enclosing
+    /// `NavigationStack`. Apply once at the root of every tab that uses
+    /// value-based `NavigationLink(value:)` to ``AppDestination``.
+    func appDestinations() -> some View {
+        modifier(AppDestinationModifier())
+    }
+}

--- a/NetMonitor-iOS/ViewModels/WorldPingToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/WorldPingToolViewModel.swift
@@ -24,11 +24,11 @@ final class WorldPingToolViewModel {
 
     // MARK: - Dependencies
 
-    private let service: any WorldPingServiceProtocol
+    private let runner: WorldPingRunner
     private var runTask: Task<Void, Never>?
 
     init(service: any WorldPingServiceProtocol = WorldPingService()) {
-        self.service = service
+        self.runner = WorldPingRunner(service: service)
     }
 
     // MARK: - Computed
@@ -61,22 +61,14 @@ final class WorldPingToolViewModel {
         errorMessage = nil
         isRunning = true
 
-        runTask = Task {
-            let stream = await service.ping(
-                host: hostInput.trimmingCharacters(in: .whitespaces),
-                maxNodes: 20
-            )
-
-            for await result in stream {
-                guard !Task.isCancelled else { break }
-                results.append(result)
-                results.sort { ($0.latencyMs ?? Double.infinity) < ($1.latencyMs ?? Double.infinity) }
+        runTask = Task { [runner] in
+            let host = hostInput.trimmingCharacters(in: .whitespaces)
+            _ = await runner.run(host: host, maxNodes: 20) { sorted in
+                results = sorted
             }
-
             guard !Task.isCancelled else { return }
-
             if results.isEmpty {
-                errorMessage = service.lastError ?? "No results returned. Check the host address and your network connection."
+                errorMessage = runner.emptyResultsMessage()
             }
             isRunning = false
         }

--- a/NetMonitor-iOS/Views/ContentView.swift
+++ b/NetMonitor-iOS/Views/ContentView.swift
@@ -3,6 +3,7 @@ import NetMonitorCore
 import SwiftData
 
 struct ContentView: View {
+    @Environment(AppEnvironment.self) private var env
     @State private var selectedTab: Tab = .dashboard
     @State private var selectedSidebarTab: Tab? = .dashboard
     // Observe ThemeManager so the entire view tree re-renders on accent color change
@@ -66,7 +67,7 @@ struct ContentView: View {
                         .tag(Tab.tools)
                         .accessibilityIdentifier("contentView_tab_tools")
 
-                    TimelineView()
+                    TimelineView(env: env)
                         .tabItem {
                             Label(Tab.timeline.title, systemImage: Tab.timeline.icon)
                         }
@@ -207,7 +208,7 @@ struct ContentView: View {
         case .dashboard: DashboardView()
         case .map: NetworkMapView()
         case .tools: ToolsView()
-        case .timeline: TimelineView()
+        case .timeline: TimelineView(env: env)
         }
     }
 }

--- a/NetMonitor-iOS/Views/ContentView.swift
+++ b/NetMonitor-iOS/Views/ContentView.swift
@@ -215,5 +215,6 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environment(AppEnvironment.live())
         .modelContainer(for: [], inMemory: true)
 }

--- a/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
+++ b/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
@@ -17,6 +17,7 @@ struct DashboardView: View {
                         .padding(.top, Theme.Layout.smallCornerRadius)
                         .padding(.bottom, Theme.Layout.sectionSpacing)
                 }
+                .appDestinations()
                 .themedBackground()
                 .navigationTitle("Dashboard")
                 .navigationBarTitleDisplayMode(.inline)
@@ -730,7 +731,7 @@ struct SpeedTestQuickCard: View {
     private var lastResult: SpeedTestResult? { history.first }
 
     var body: some View {
-        NavigationLink(destination: SpeedTestToolView()) {
+        NavigationLink(value: AppDestination.speedTest) {
             GlassCard(padding: 14, statusGlow: Theme.Colors.info) {
                 HStack(spacing: 14) {
                     ZStack {
@@ -784,7 +785,7 @@ struct SpeedTestQuickCard: View {
 
 struct WiFiHeatmapQuickCard: View {
     var body: some View {
-        NavigationLink(destination: HeatmapSurveyView()) {
+        NavigationLink(value: AppDestination.heatmapSurvey) {
             GlassCard(padding: 14) {
                 HStack(spacing: 14) {
                     ZStack {

--- a/NetMonitor-iOS/Views/Dashboard/DeviceListView.swift
+++ b/NetMonitor-iOS/Views/Dashboard/DeviceListView.swift
@@ -97,7 +97,7 @@ struct DeviceListView: View {
                     .padding(.horizontal, Theme.Layout.screenPadding)
 
                     ForEach(sortedDevices) { device in
-                        NavigationLink(destination: DeviceDetailView(ipAddress: device.ipAddress)) {
+                        NavigationLink(value: AppDestination.deviceDetail(ipAddress: device.ipAddress)) {
                             if isProMode {
                                 proModeRow(device: device)
                             } else {

--- a/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
+++ b/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
@@ -404,7 +404,7 @@ struct DeviceDetailView: View {
 
             VStack(spacing: Theme.Layout.itemSpacing) {
                 // Ping button
-                NavigationLink(destination: PingToolView(initialHost: device.ipAddress)) {
+                NavigationLink(value: AppDestination.ping(host: device.ipAddress)) {
                     HStack {
                         Image(systemName: "antenna.radiowaves.left.and.right")
                             .foregroundStyle(Theme.Colors.accent)
@@ -426,7 +426,7 @@ struct DeviceDetailView: View {
                 Divider().background(Theme.Colors.glassBorder)
 
                 // Port Scan button
-                NavigationLink(destination: PortScannerToolView(initialHost: device.ipAddress)) {
+                NavigationLink(value: AppDestination.portScanner(host: device.ipAddress)) {
                     HStack {
                         Image(systemName: "server.rack")
                             .foregroundStyle(Theme.Colors.accent)
@@ -448,7 +448,7 @@ struct DeviceDetailView: View {
                 Divider().background(Theme.Colors.glassBorder)
 
                 // DNS Lookup button
-                NavigationLink(destination: DNSLookupToolView(initialDomain: device.ipAddress)) {
+                NavigationLink(value: AppDestination.dnsLookup(domain: device.ipAddress)) {
                     HStack {
                         Image(systemName: "globe")
                             .foregroundStyle(Theme.Colors.accent)
@@ -471,7 +471,7 @@ struct DeviceDetailView: View {
                 if device.supportsWakeOnLan {
                     Divider().background(Theme.Colors.glassBorder)
 
-                    NavigationLink(destination: WakeOnLANToolView(initialMacAddress: device.macAddress)) {
+                    NavigationLink(value: AppDestination.wakeOnLAN(mac: device.macAddress)) {
                         HStack {
                             Image(systemName: "power")
                                 .foregroundStyle(Theme.Colors.success)

--- a/NetMonitor-iOS/Views/NetworkMap/NetworkMapView.swift
+++ b/NetMonitor-iOS/Views/NetworkMap/NetworkMapView.swift
@@ -77,7 +77,7 @@ struct NetworkMapView: View {
                     } else {
                         VStack(spacing: 8) {
                             ForEach(sortedDevices) { device in
-                                NavigationLink(destination: DeviceDetailView(ipAddress: device.ipAddress)) {
+                                NavigationLink(value: AppDestination.deviceDetail(ipAddress: device.ipAddress)) {
                                     ProDeviceRow(device: device, isScanning: viewModel.isScanning)
                                 }
                                 .buttonStyle(PlainButtonStyle())
@@ -90,6 +90,7 @@ struct NetworkMapView: View {
                 .padding(.top, Theme.Layout.smallCornerRadius)
                 .padding(.bottom, Theme.Layout.sectionSpacing)
             }
+            .appDestinations()
             .themedBackground()
             .navigationTitle("Network Map")
             .accessibilityIdentifier("screen_networkMap")

--- a/NetMonitor-iOS/Views/Timeline/TimelineView.swift
+++ b/NetMonitor-iOS/Views/Timeline/TimelineView.swift
@@ -2,8 +2,12 @@ import SwiftUI
 import NetMonitorCore
 
 struct TimelineView: View {
-    @State private var viewModel = TimelineViewModel()
+    @State private var viewModel: TimelineViewModel
     @State private var showingFilterSheet = false
+
+    init(env: AppEnvironment) {
+        _viewModel = State(initialValue: TimelineViewModel(service: env.eventService))
+    }
 
     var body: some View {
         NavigationStack {
@@ -237,5 +241,5 @@ struct TimelineFilterSheet: View {
 }
 
 #Preview {
-    TimelineView()
+    TimelineView(env: .live())
 }

--- a/NetMonitor-macOS/ViewModels/WorldPingToolViewModel.swift
+++ b/NetMonitor-macOS/ViewModels/WorldPingToolViewModel.swift
@@ -17,11 +17,11 @@ final class MacWorldPingToolViewModel {
 
     // MARK: - Dependencies
 
-    private let service: any WorldPingServiceProtocol
+    private let runner: WorldPingRunner
     private var runTask: Task<Void, Never>?
 
     init(service: any WorldPingServiceProtocol = WorldPingService()) {
-        self.service = service
+        self.runner = WorldPingRunner(service: service)
     }
 
     // MARK: - Computed
@@ -46,18 +46,13 @@ final class MacWorldPingToolViewModel {
         errorMessage = nil
         isRunning = true
 
-        runTask = Task {
-            let stream = await service.ping(host: host, maxNodes: 20)
-            for await result in stream {
-                guard !Task.isCancelled else { break }
-                results.append(result)
-                results.sort { ($0.latencyMs ?? .infinity) < ($1.latencyMs ?? .infinity) }
+        runTask = Task { [runner] in
+            _ = await runner.run(host: host, maxNodes: 20) { sorted in
+                results = sorted
             }
-
             guard !Task.isCancelled else { return }
-
             if results.isEmpty {
-                errorMessage = service.lastError ?? "No results returned. Check the host and your network connection."
+                errorMessage = runner.emptyResultsMessage()
             }
             isRunning = false
         }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingRunner.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingRunner.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - WorldPingRunner
+
+/// Encapsulates the duplicated run-and-accumulate loop that was previously
+/// inlined in both `WorldPingToolViewModel` (iOS) and
+/// `MacWorldPingToolViewModel` (macOS). Owns the `WorldPingServiceProtocol`
+/// reference and the result-sorting policy; callers own the `Task` lifecycle
+/// and the observable result array.
+///
+/// The runner is `Sendable` so it can be stored on `@MainActor @Observable`
+/// VMs without isolation friction.
+public struct WorldPingRunner: Sendable {
+    public let service: any WorldPingServiceProtocol
+
+    public init(service: any WorldPingServiceProtocol) {
+        self.service = service
+    }
+
+    /// Streams the service's results, sorting the accumulator by ascending
+    /// latency after each yield. Calls `onUpdate` on the @MainActor with the
+    /// current sorted snapshot so the VM's `@Observable` array assignment
+    /// triggers a SwiftUI redraw.
+    ///
+    /// Returns the final accumulated results, or a partial accumulation if
+    /// the task is cancelled. Callers should check `Task.isCancelled` after
+    /// `await` to decide whether to apply terminal state.
+    @MainActor
+    public func run(
+        host: String,
+        maxNodes: Int = 20,
+        onUpdate: @MainActor (_ results: [WorldPingLocationResult]) -> Void
+    ) async -> [WorldPingLocationResult] {
+        var accumulated: [WorldPingLocationResult] = []
+        let stream = await service.ping(host: host, maxNodes: maxNodes)
+        for await result in stream {
+            guard !Task.isCancelled else { break }
+            accumulated.append(result)
+            accumulated.sort { ($0.latencyMs ?? .infinity) < ($1.latencyMs ?? .infinity) }
+            onUpdate(accumulated)
+        }
+        return accumulated
+    }
+
+    /// Convenience: pulls the trimmed `lastError` off the underlying service
+    /// or returns a default empty-results message. Used by VMs when the
+    /// stream finishes with no results.
+    public func emptyResultsMessage(default: String = "No results returned. Check the host and your network connection.") -> String {
+        service.lastError ?? `default`
+    }
+}


### PR DESCRIPTION
## Summary

Two iOS-wide architectural refactors that touch the same set of root view files, bundled into one PR.

Base chained on \`arch-review/p2-batch-wave2\` (PR #229); auto-rebases to \`arch-review/p2-batch\` then \`main\` as upstream PRs merge.

| Item | Issue | Commit |
|---|---|---|
| Convert legacy `NavigationLink(destination:)` → value-based routing | #211 | `c84fefd` |
| Establish `AppEnvironment` composition root + migrate first root VM | #209 | `ad97e97` |

## #211 — value-based NavigationLink routing

Replaced 8 legacy `NavigationLink(destination:)` call sites with the typed value-based form fed by a single `AppDestination` enum.

- New `NetMonitor-iOS/Navigation/AppDestination.swift` — `enum AppDestination: Hashable { case deviceDetail(ipAddress:), ping(host:), portScanner(host:), dnsLookup(domain:), wakeOnLAN(mac:), speedTest, heatmapSurvey }`. `AppDestinationModifier` registers `.navigationDestination(for: AppDestination.self) { ... }`. Exposed via `View.appDestinations()`.
- `.appDestinations()` installed on the root `NavigationStack` of `DashboardView` and `NetworkMapView`. Descendants (`DeviceListView`, `DeviceDetailView`) push into the same stacks so their `NavigationLink(value:)` calls resolve via the parent's `.appDestinations()`.
- 8 NavigationLinks updated: 2 in `DashboardView` (SpeedTest, HeatmapSurvey), 1 in `DeviceListView` (DeviceDetail), 1 in `NetworkMapView` (DeviceDetail), 4 in `DeviceDetailView` (Ping, PortScanner, DNS, WakeOnLAN — each carrying a parameter).

**Part-1 audit result:** the two `NavigationStack` instances called out by the original consensus (`WHOISToolView:219`, `GeoTraceView:266`) were already in `#Preview` blocks, not in production view bodies. Verified across all 14 `*ToolView.swift` files: only `ToolsView` has a `NavigationStack` in its body (correctly, as the Tools tab root). No silent-swallow bug to fix here.

## #209 — composition root scaffold + first migration

iOS had `Service.shared` defaults baked into 6+ root ViewModel init signatures and scattered `.onAppear` service bootstraps — production diverged from tests at every VM construction site.

- New `NetMonitor-iOS/App/AppEnvironment.swift` — `@MainActor @Observable final class AppEnvironment` holding 9 foundational services: `NetworkMonitorService`, `DeviceDiscoveryService`, `MacConnectionService`, `PublicIPService`, `WiFiInfoService`, `TargetManager`, `ToolActivityLog`, `NetworkEventService`, `ScanSchedulerService`. `AppEnvironment.live()` factory wires them from the current `*.shared` instances so the `@main` lifecycle hooks (`EventListenerService`, `BackgroundTaskService`, `ObservabilityService`) keep observing the same state during the migration.
- `NetmonitorApp.swift` — `@State private var environment: AppEnvironment = .live()` injected via `.environment(environment)` on the root `ContentView`.
- **Migration started** — `TimelineView` now takes `env: AppEnvironment` in its `init(env:)` and constructs its VM with `env.eventService`. `ContentView` reads `@Environment(AppEnvironment.self)` and threads it to the timeline tab at both iPhone (`TabView`) and iPad (`detailView`) call sites. Preview updated to pass `.live()`.
- **What's NOT migrated yet:** `DashboardViewModel`, `NetworkMapViewModel`, `ToolsViewModel`, `NetworkHealthScoreViewModel`, `ScheduledScanViewModel`. They keep their existing `Service.shared` defaults so no tests or sub-views break. Each can be migrated one-at-a-time following the `TimelineView` pattern in a follow-up PR.

This is honest "scaffold + sample" — the structural pattern is in place and demonstrated end-to-end on one VM. Mass migration of remaining VMs is mechanical follow-up.

## Verification

- `swift build` clean for `NetMonitorCore` on each commit.
- SwiftLint + SwiftFormat clean via pre-commit hook on both commits.
- iOS target compile + full Swift Testing run wants Mac mini verification.

## Test plan

- [ ] `ssh mac-mini "cd ~/Projects/NetMonitor-2.0 && xcodebuild test -scheme NetMonitor-iOS -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:NetMonitor-iOSTests"`
- [ ] Manual iPhone — verify Dashboard → SpeedTest, Dashboard → Heatmap, Network Map → Device → Tool (Ping/PortScan/DNS/WakeOnLAN), Device List → Device. Each push should land on the correct destination view and back-swipe should work.
- [ ] Manual iPad — same flows, but verify the sidebar→detail split still routes correctly.
- [ ] Manual iPhone — open the Timeline tab. Verify it loads with events as before (this confirms `AppEnvironment.live().eventService` returns the same `NetworkEventService.shared` the rest of the app uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)