### PR TITLE
perf(scan): reuse shared queue in quickPortScan (#203)

### DIFF
--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -401,13 +401,13 @@ final class DeviceDiscoveryCoordinator {
     /// fresh `DispatchQueue`. Concurrent attribute preserves parallel fan-out across
     /// ports/devices (15 ports x N devices were previously running on N*15 disposable
     /// queues per scan). See #203.
-    private static let portScanQueue = DispatchQueue(
+    nonisolated private static let portScanQueue = DispatchQueue(
         label: "com.netmonitor.quickportscan",
         attributes: .concurrent
     )
 
     /// Non-blocking TCP connect check with configurable timeout.
-    private static func checkPort(host: String, port: Int, timeoutMs: Int32) async -> Bool {
+    nonisolated private static func checkPort(host: String, port: Int, timeoutMs: Int32) async -> Bool {
         await withCheckedContinuation { continuation in
             portScanQueue.async {
                 var hints = addrinfo()

--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -403,6 +403,7 @@ final class DeviceDiscoveryCoordinator {
     /// queues per scan). See #203.
     nonisolated private static let portScanQueue = DispatchQueue(
         label: "com.netmonitor.quickportscan",
+        qos: .userInitiated,
         attributes: .concurrent
     )
 

--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -397,10 +397,19 @@ final class DeviceDiscoveryCoordinator {
         loadPersistedDevices(for: profileID)
     }
 
+    /// Shared concurrent queue for `checkPort` so each TCP probe doesn't allocate a
+    /// fresh `DispatchQueue`. Concurrent attribute preserves parallel fan-out across
+    /// ports/devices (15 ports x N devices were previously running on N*15 disposable
+    /// queues per scan). See #203.
+    private static let portScanQueue = DispatchQueue(
+        label: "com.netmonitor.quickportscan",
+        attributes: .concurrent
+    )
+
     /// Non-blocking TCP connect check with configurable timeout.
     private static func checkPort(host: String, port: Int, timeoutMs: Int32) async -> Bool {
         await withCheckedContinuation { continuation in
-            DispatchQueue(label: "com.netmonitor.quickportscan").async {
+            portScanQueue.async {
                 var hints = addrinfo()
                 hints.ai_family = AF_INET
                 hints.ai_socktype = SOCK_STREAM


### PR DESCRIPTION
`DeviceDiscoveryCoordinator.checkPort` previously allocated a fresh `DispatchQueue(label: "com.netmonitor.quickportscan")` per probe inside `withCheckedContinuation`. For a typical quick scan that is 15 ports x N devices = 150+ disposable GCD queues per scan, each created, used once for a non-blocking connect/poll, then discarded.

Replace the per-call allocation with a single file-scoped `private static let portScanQueue` configured with `attributes: .concurrent`. The concurrent attribute is essential — a serial queue would have serialised all 150 port checks, and closed ports hit the full 1000ms timeout, so the scan would have stretched from seconds to minutes.

Mirrors the existing module-level `scanQueue` pattern used by `NetworkScanKit/Phases/BonjourScanPhase.swift` and consumed by the `NWConnection`-based probes in `TCPProbeScanPhase`.

Closes #203.

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
