### PR TITLE
chore: delete 3 dead protocols/types (#204)

### DIFF
--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
@@ -329,11 +329,6 @@ public struct ScanDiff: Sendable {
 
 // MARK: - New Feature Service Protocols
 
-/// Protocol for subnet calculation.
-public protocol SubnetCalculatorServiceProtocol: AnyObject, Sendable {
-    func calculate(cidr: String) -> SubnetInfo?
-}
-
 /// Protocol for world ping (global latency checks via external API).
 public protocol WorldPingServiceProtocol: AnyObject, Sendable {
     var lastError: String? { get }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/TracerouteService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/TracerouteService.swift
@@ -19,7 +19,7 @@ public actor TracerouteService: TracerouteServiceProtocol {
 
     // MARK: - State
 
-    private var isRunning = false
+    public private(set) var isRunning = false
 
     // MARK: - Initialization
 
@@ -56,11 +56,6 @@ public actor TracerouteService: TracerouteServiceProtocol {
     /// Stops the current traceroute operation.
     public func stop() async {
         isRunning = false
-    }
-
-    /// Returns whether a traceroute is currently running.
-    public var running: Bool {
-        isRunning
     }
 
     // MARK: - Private Implementation

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceIntegrationTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceIntegrationTests.swift
@@ -113,7 +113,7 @@ struct TracerouteServiceIntegrationTests {
         #expect(count >= 1, "Stream must have yielded at least one hop before stop()")
 
         // Verify the service is no longer running
-        let isRunning = await service.running
+        let isRunning = await service.isRunning
         #expect(isRunning == false, "Service must not be in running state after stop()")
     }
 
@@ -123,7 +123,7 @@ struct TracerouteServiceIntegrationTests {
         for await _ in await service.trace(host: "127.0.0.1", maxHops: 1, timeout: 3.0) {
             // consume all hops
         }
-        let isRunning = await service.running
+        let isRunning = await service.isRunning
         #expect(isRunning == false, "running must be false after the stream finishes naturally")
     }
 

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/TracerouteServiceTests.swift
@@ -104,10 +104,10 @@ struct TracerouteServiceTests {
 
     // MARK: - Initial state
 
-    @Test("running is false before any trace")
+    @Test("isRunning is false before any trace")
     func runningIsFalseBeforeAnyTrace() async {
         let service = TracerouteService()
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false)
     }
 
@@ -118,7 +118,7 @@ struct TracerouteServiceTests {
         let service = TracerouteService()
         await service.stop()
         await service.stop()
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false)
     }
 

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanContext.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanContext.swift
@@ -11,9 +11,6 @@ public struct ScanContext: Sendable {
     /// The local device's IP address (excluded from probing).
     public let localIP: String?
 
-    /// The network profile associated with this scan.
-    public let networkProfile: NetworkScanProfile?
-
     /// The scan strategy determining which phases are included.
     public let scanStrategy: ScanStrategy
 
@@ -21,13 +18,11 @@ public struct ScanContext: Sendable {
         hosts: [String],
         subnetFilter: @escaping @Sendable (String) -> Bool,
         localIP: String?,
-        networkProfile: NetworkScanProfile? = nil,
         scanStrategy: ScanStrategy = .full
     ) {
         self.hosts = hosts
         self.subnetFilter = subnetFilter
         self.localIP = localIP
-        self.networkProfile = networkProfile
         self.scanStrategy = scanStrategy
     }
 }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanContextTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanContextTests.swift
@@ -45,27 +45,7 @@ struct ScanContextTests {
         #expect(ctx.subnetFilter("192.168.1.1") == false)
     }
 
-    // MARK: - NetworkProfile and ScanStrategy
-
-    @Test("networkProfile defaults to nil")
-    func networkProfileDefaultsToNil() {
-        let ctx = ScanContext(hosts: [], subnetFilter: { _ in true }, localIP: nil)
-        #expect(ctx.networkProfile == nil)
-    }
-
-    @Test("networkProfile is stored when provided")
-    func networkProfileStored() {
-        let profile = NetworkScanProfile(id: "home-5ghz", name: "Home 5GHz", subnetCIDR: "192.168.1.0/24")
-        let ctx = ScanContext(
-            hosts: [],
-            subnetFilter: { _ in true },
-            localIP: nil,
-            networkProfile: profile
-        )
-        #expect(ctx.networkProfile?.id == "home-5ghz")
-        #expect(ctx.networkProfile?.name == "Home 5GHz")
-        #expect(ctx.networkProfile?.subnetCIDR == "192.168.1.0/24")
-    }
+    // MARK: - ScanStrategy
 
     @Test("scanStrategy defaults to .full")
     func scanStrategyDefaultsToFull() {
@@ -97,19 +77,16 @@ struct ScanContextTests {
 
     @Test("full context with all parameters")
     func fullContext() {
-        let profile = NetworkScanProfile(id: "office", name: "Office Network")
         let ctx = ScanContext(
             hosts: ["10.0.0.1"],
             subnetFilter: { ip in ip.hasPrefix("10.0.") },
             localIP: "10.0.0.50",
-            networkProfile: profile,
             scanStrategy: .remote
         )
 
         #expect(ctx.hosts == ["10.0.0.1"])
         #expect(ctx.subnetFilter("10.0.0.1") == true)
         #expect(ctx.localIP == "10.0.0.50")
-        #expect(ctx.networkProfile?.id == "office")
         #expect(ctx.scanStrategy == .remote)
     }
 }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanStrategyCoverageTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanStrategyCoverageTests.swift
@@ -134,25 +134,22 @@ struct ScanStrategyCoverageTests {
         #expect(closure().id == "s")
     }
 
-    // MARK: - ScanContext with NetworkScanProfile and ScanStrategy
+    // MARK: - ScanContext with ScanStrategy
 
-    @Test("ScanContext with .remote strategy and profile")
-    func contextWithRemoteStrategyAndProfile() {
-        let profile = NetworkScanProfile(id: "remote-office", name: "Remote Office", subnetCIDR: "10.10.0.0/16")
+    @Test("ScanContext with .remote strategy")
+    func contextWithRemoteStrategy() {
         let ctx = ScanContext(
             hosts: ["10.10.0.1"],
             subnetFilter: { _ in true },
             localIP: nil,
-            networkProfile: profile,
             scanStrategy: .remote
         )
         #expect(ctx.scanStrategy == .remote)
-        #expect(ctx.networkProfile?.id == "remote-office")
-        #expect(ctx.networkProfile?.subnetCIDR == "10.10.0.0/16")
+        #expect(ctx.hosts == ["10.10.0.1"])
     }
 
-    @Test("ScanContext with .full strategy and nil profile")
-    func contextWithFullStrategyNilProfile() {
+    @Test("ScanContext with .full strategy")
+    func contextWithFullStrategy() {
         let ctx = ScanContext(
             hosts: [],
             subnetFilter: { _ in true },
@@ -160,7 +157,6 @@ struct ScanStrategyCoverageTests {
             scanStrategy: .full
         )
         #expect(ctx.scanStrategy == .full)
-        #expect(ctx.networkProfile == nil)
         #expect(ctx.localIP == "192.168.1.100")
     }
 

--- a/Tests/NetMonitor-macOSTests/TracerouteServiceErrorSurfacingTests.swift
+++ b/Tests/NetMonitor-macOSTests/TracerouteServiceErrorSurfacingTests.swift
@@ -59,7 +59,7 @@ struct TracerouteServiceErrorSurfacingTests {
         // Consume the stream
         for await _ in stream {}
 
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "running should be false after trace completes")
     }
 
@@ -74,7 +74,7 @@ struct TracerouteServiceErrorSurfacingTests {
         // Drain remaining items
         for await _ in stream {}
 
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "Service should not be stuck in running state after stop()")
     }
 
@@ -105,7 +105,7 @@ struct TracerouteServiceErrorSurfacingTests {
 
         // localhost trace should complete (either with hops or timeout) — not hang forever.
         // The key assertion is that we reach this point (stream finishes).
-        let running = await service.running
+        let running = await service.isRunning
         #expect(running == false, "Trace to localhost should complete and set running to false")
     }
 }


### PR DESCRIPTION
Removed dead code identified by arch-review consensus (2026-05-10):

- SubnetCalculatorServiceProtocol (ServiceProtocols.swift:330) Zero conformers in the repo. iOS/macOS SubnetCalculatorToolViewModel perform calculations inline without going through the protocol.
- ScanContext.networkProfile (ScanContext.swift:14-15) Stored in init but never read by any scan phase. Removed from struct, init signature, and all test call sites.
- TracerouteService.running (TracerouteService.swift:61-64) Public alias for private isRunning, consumed only by tests. Made isRunning public(set) and updated 7 test sites across 3 files to use isRunning directly.

Skipped DeviceNameResolverProtocol (also flagged in the issue): it has an active retroactive conformance in NetMonitor-iOS/Platform/SharedServices.swift and is used as a DI seam by DeviceDetailViewModel (with MockDeviceNameResolver in tests). Not dead.

SubnetInfo struct is preserved — it remains in use by SubnetCalculatorToolView (macOS) and SubnetCalculatorToolViewModel (iOS).

swift build passes for NetMonitorCore and NetworkScanKit. Test targets also compile (--build-tests).

Closes #204.

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
