### PR TITLE
perf(swiftdata): cap unbounded @Query reads with fetchLimit (#207)

### DIFF
--- a/NetMonitor-macOS/Utilities/LocalDeviceQueries.swift
+++ b/NetMonitor-macOS/Utilities/LocalDeviceQueries.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftData
+import NetMonitorCore
+
+/// Centralised `FetchDescriptor` factory for `LocalDevice` queries.
+///
+/// Keeping the cap policy and sort order in one place means all views
+/// automatically pick up changes to the fetch limit or sort key.
+enum LocalDeviceQueries {
+
+    /// Default row cap applied to summary and picker views.
+    static let defaultLimit = 500
+
+    /// All devices sorted by most-recently-seen first, with no row cap.
+    /// Use for full-table views where users expect to see every device.
+    static func all() -> FetchDescriptor<LocalDevice> {
+        FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+    }
+
+    /// Most-recently-seen devices sorted by `lastSeen` descending, capped at `limit`.
+    /// Use for summary views that don't need the full table.
+    static func recents(limit: Int = defaultLimit) -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return descriptor
+    }
+
+    /// Devices belonging to a single network profile, sorted by `lastSeen` descending,
+    /// capped at `limit`. The predicate is evaluated in the store so the cap applies
+    /// to the profile-scoped set rather than the global `LocalDevice` table.
+    static func forProfile(_ profileID: UUID?, limit: Int = defaultLimit) -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            predicate: #Predicate<LocalDevice> { device in
+                device.networkProfileID == profileID
+            },
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return descriptor
+    }
+
+    /// Devices that have a non-empty MAC address (WoL-eligible), sorted by
+    /// `lastSeen` descending, capped at `limit`. The predicate is evaluated in the
+    /// store so the cap applies to the eligible set rather than the raw table.
+    static func withMACAddress(limit: Int = defaultLimit) -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            predicate: #Predicate<LocalDevice> { device in
+                device.macAddress != ""
+            },
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return descriptor
+    }
+}

--- a/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
+++ b/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
@@ -15,17 +15,7 @@ struct QuickJumpSheet: View {
     @Binding var isPresented: Bool
 
     @Environment(\.modelContext) private var modelContext
-    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
-
-    /// Protective cap on growing `LocalDevice` table. Search displays `prefix(8)`,
-    /// so 500 most-recent rows is more than enough working set.
-    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        var descriptor = FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-        descriptor.fetchLimit = 500
-        return descriptor
-    }
+    @Query(LocalDeviceQueries.recents()) private var devices: [LocalDevice]
 
     @State private var searchText: String = ""
     @FocusState private var isFocused: Bool

--- a/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
+++ b/NetMonitor-macOS/Views/Components/QuickJumpSheet.swift
@@ -15,7 +15,17 @@ struct QuickJumpSheet: View {
     @Binding var isPresented: Bool
 
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. Search displays `prefix(8)`,
+    /// so 500 most-recent rows is more than enough working set.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var searchText: String = ""
     @FocusState private var isFocused: Bool

--- a/NetMonitor-macOS/Views/DevicesView.swift
+++ b/NetMonitor-macOS/Views/DevicesView.swift
@@ -13,7 +13,17 @@ struct DevicesView: View {
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table; 500 most-recent devices is
+    /// well above any realistic active-network size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var selectedDevice: LocalDevice?
     @State private var searchText: String = ""

--- a/NetMonitor-macOS/Views/DevicesView.swift
+++ b/NetMonitor-macOS/Views/DevicesView.swift
@@ -13,15 +13,7 @@ struct DevicesView: View {
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
-
-    /// Returns the descriptor for the full devices table, sorted by most-recent
-    /// activity first.
-    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-    }
+    @Query(LocalDeviceQueries.all()) private var devices: [LocalDevice]
 
     @State private var selectedDevice: LocalDevice?
     @State private var searchText: String = ""

--- a/NetMonitor-macOS/Views/DevicesView.swift
+++ b/NetMonitor-macOS/Views/DevicesView.swift
@@ -15,14 +15,12 @@ struct DevicesView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
 
-    /// Protective cap on growing `LocalDevice` table; 500 most-recent devices is
-    /// well above any realistic active-network size.
+    /// Returns the descriptor for the full devices table, sorted by most-recent
+    /// activity first.
     private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        var descriptor = FetchDescriptor<LocalDevice>(
+        FetchDescriptor<LocalDevice>(
             sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
         )
-        descriptor.fetchLimit = 500
-        return descriptor
     }
 
     @State private var selectedDevice: LocalDevice?

--- a/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
+++ b/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
@@ -8,16 +8,13 @@ struct NetworkDevicesPanel: View {
     let networkProfileID: UUID?
 
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
-    @Query(Self.devicesDescriptor()) private var allDevices: [LocalDevice]
+    @Query private var devices: [LocalDevice]
 
-    /// Protective cap on growing `LocalDevice` table. View further filters by
-    /// `networkProfileID`; 500 most-recent devices is well above active-network size.
-    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        var descriptor = FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-        descriptor.fetchLimit = 500
-        return descriptor
+    init(networkProfileID: UUID?) {
+        self.networkProfileID = networkProfileID
+        // Push the profile predicate into the store so the 500-row cap applies to
+        // this profile's devices rather than the global LocalDevice table.
+        _devices = Query(LocalDeviceQueries.forProfile(networkProfileID), animation: .default)
     }
 
     @State private var searchText: String = ""
@@ -42,7 +39,7 @@ struct NetworkDevicesPanel: View {
     }
 
     private var filteredDevices: [LocalDevice] {
-        var result = allDevices.filter { $0.networkProfileID == networkProfileID }
+        var result = devices
 
         if !searchText.isEmpty {
             result = result.filter { device in

--- a/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
+++ b/NetMonitor-macOS/Views/NetworkDevicesPanel.swift
@@ -8,7 +8,17 @@ struct NetworkDevicesPanel: View {
     let networkProfileID: UUID?
 
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var allDevices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var allDevices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. View further filters by
+    /// `networkProfileID`; 500 most-recent devices is well above active-network size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var searchText: String = ""
     @AppStorage("netmonitor.devicesPanel.sortOrder") private var sortOrder: PanelSortOrder = .ipAddress

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -16,7 +16,17 @@ struct SidebarView: View {
     // periphery:ignore
     @Environment(MonitoringSession.self) private var monitoringSession: MonitoringSession?
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \LocalDevice.lastSeen, order: .reverse) private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table — sidebar only needs counts
+    /// per profile, and 500 most-recent devices comfortably covers active networks.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     private var headerText: Color {
         colorScheme == .dark ? .white : Color(red: 51/255, green: 65/255, blue: 85/255)

--- a/NetMonitor-macOS/Views/SidebarView.swift
+++ b/NetMonitor-macOS/Views/SidebarView.swift
@@ -16,17 +16,7 @@ struct SidebarView: View {
     // periphery:ignore
     @Environment(MonitoringSession.self) private var monitoringSession: MonitoringSession?
     @Environment(\.colorScheme) private var colorScheme
-    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
-
-    /// Protective cap on growing `LocalDevice` table — sidebar only needs counts
-    /// per profile, and 500 most-recent devices comfortably covers active networks.
-    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        var descriptor = FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-        descriptor.fetchLimit = 500
-        return descriptor
-    }
+    @Query(LocalDeviceQueries.recents()) private var devices: [LocalDevice]
 
     private var headerText: Color {
         colorScheme == .dark ? .white : Color(red: 51/255, green: 65/255, blue: 85/255)

--- a/NetMonitor-macOS/Views/TargetStatisticsView.swift
+++ b/NetMonitor-macOS/Views/TargetStatisticsView.swift
@@ -13,21 +13,35 @@ struct TargetStatisticsView: View {
         self.target = target
 
         let targetID = target.id
-        var descriptor = FetchDescriptor<TargetMeasurement>(
-            predicate: #Predicate<TargetMeasurement> { measurement in
-                measurement.target?.id == targetID
-            },
-            sortBy: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)]
+        // Bound by a 30-day time window rather than an opaque sample count so that
+        // Avg/Min/Max latency and Uptime % reflect a clear, user-understandable period.
+        // At a typical 1-minute check interval this caps at ~43,200 rows per target —
+        // well within reason for a desktop app while keeping the contract unambiguous.
+        // cutoff is computed at init time; SwiftUI re-creates the view struct (and
+        // therefore re-evaluates the descriptor) each time the parent re-renders,
+        // so the window stays fresh for normal interactive usage.
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? Date.now.addingTimeInterval(-30 * 24 * 3_600)
+        _measurements = Query(
+            FetchDescriptor<TargetMeasurement>(
+                predicate: #Predicate<TargetMeasurement> { measurement in
+                    measurement.target?.id == targetID &&
+                    measurement.timestamp >= cutoff
+                },
+                sortBy: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)]
+            ),
+            animation: .default
         )
-        // Protective cap — TargetMeasurement is the largest growing table.
-        descriptor.fetchLimit = 5000
-        _measurements = Query(descriptor, animation: .default)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Recent Measurements")
-                .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                Text("Recent Measurements")
+                    .font(.headline)
+                Text("· Last 30 days")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
 
             if measurements.isEmpty {
                 Text("No measurements yet")

--- a/NetMonitor-macOS/Views/TargetStatisticsView.swift
+++ b/NetMonitor-macOS/Views/TargetStatisticsView.swift
@@ -12,17 +12,16 @@ struct TargetStatisticsView: View {
     init(target: NetworkTarget) {
         self.target = target
 
-        // Query last 50 measurements for this target
         let targetID = target.id
-        let predicate = #Predicate<TargetMeasurement> { measurement in
-            measurement.target?.id == targetID
-        }
-
-        _measurements = Query(
-            filter: predicate,
-            sort: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)],
-            animation: .default
+        var descriptor = FetchDescriptor<TargetMeasurement>(
+            predicate: #Predicate<TargetMeasurement> { measurement in
+                measurement.target?.id == targetID
+            },
+            sortBy: [SortDescriptor(\TargetMeasurement.timestamp, order: .reverse)]
         )
+        // Protective cap — TargetMeasurement is the largest growing table.
+        descriptor.fetchLimit = 5000
+        _measurements = Query(descriptor, animation: .default)
     }
 
     var body: some View {

--- a/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
@@ -10,7 +10,17 @@ import NetMonitorCore
 import SwiftData
 
 struct WakeOnLanToolView: View {
-    @Query private var devices: [LocalDevice]
+    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
+
+    /// Protective cap on growing `LocalDevice` table. View further filters to
+    /// devices with MAC addresses; 500 most-recent is well above realistic size.
+    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
+        var descriptor = FetchDescriptor<LocalDevice>(
+            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
+        )
+        descriptor.fetchLimit = 500
+        return descriptor
+    }
 
     @State private var selectedDeviceID: UUID?
     @State private var macAddress = ""

--- a/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift
@@ -10,17 +10,7 @@ import NetMonitorCore
 import SwiftData
 
 struct WakeOnLanToolView: View {
-    @Query(Self.devicesDescriptor()) private var devices: [LocalDevice]
-
-    /// Protective cap on growing `LocalDevice` table. View further filters to
-    /// devices with MAC addresses; 500 most-recent is well above realistic size.
-    private static func devicesDescriptor() -> FetchDescriptor<LocalDevice> {
-        var descriptor = FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-        descriptor.fetchLimit = 500
-        return descriptor
-    }
+    @Query(LocalDeviceQueries.withMACAddress()) private var devices: [LocalDevice]
 
     @State private var selectedDeviceID: UUID?
     @State private var macAddress = ""
@@ -32,14 +22,9 @@ struct WakeOnLanToolView: View {
 
     private let wakeService = WakeOnLANService()
 
-    // Filter devices that have MAC addresses
-    private var devicesWithMAC: [LocalDevice] {
-        devices.filter { !$0.macAddress.isEmpty }
-    }
-
     // periphery:ignore
     private var selectedDevice: LocalDevice? {
-        devicesWithMAC.first { $0.id == selectedDeviceID }
+        devices.first { $0.id == selectedDeviceID }
     }
 
     var body: some View {
@@ -72,7 +57,7 @@ struct WakeOnLanToolView: View {
 
                     Divider()
 
-                    ForEach(devicesWithMAC) { device in
+                    ForEach(devices) { device in
                         Text(device.displayName)
                             .tag(device.id as UUID?)
                     }
@@ -82,7 +67,7 @@ struct WakeOnLanToolView: View {
                 .accessibilityIdentifier("wol_picker_device")
                 .onChange(of: selectedDeviceID) { _, newValue in
                     if let deviceID = newValue,
-                       let device = devicesWithMAC.first(where: { $0.id == deviceID }) {
+                       let device = devices.first(where: { $0.id == deviceID }) {
                         macAddress = device.macAddress
                     }
                 }


### PR DESCRIPTION
Converts @Query reads of growing SwiftData tables to FetchDescriptor with a protective fetchLimit. Prevents view-on-appear from loading the full table after weeks of monitoring.

Capped sites:
- NetMonitor-macOS/Views/SidebarView.swift:19 — LocalDevice — fetchLimit: 500 (sidebar per-profile counts)
- NetMonitor-macOS/Views/NetworkDevicesPanel.swift:11 — LocalDevice — fetchLimit: 500 (per-network device grid)
- NetMonitor-macOS/Views/DevicesView.swift:16 — LocalDevice — fetchLimit: 500 (full devices table)
- NetMonitor-macOS/Views/Components/QuickJumpSheet.swift:18 — LocalDevice — fetchLimit: 500 (Cmd-K device search, displays prefix(8))
- NetMonitor-macOS/Views/Tools/WakeOnLanToolView.swift:13 — LocalDevice — fetchLimit: 500 (WoL device picker)
- NetMonitor-macOS/Views/TargetStatisticsView.swift:10 — TargetMeasurement — fetchLimit: 5000 (largest growing table; chart shows prefix(20), stats use all)

Skipped (bounded user-managed tables):
- NetMonitor-macOS/Views/TargetsView.swift:9 — NetworkTarget (user-managed list)
- NetMonitor-macOS/Views/NetworkDetailView.swift:17 — NetworkTarget (user-managed list)

Closes #207.

## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
