### PR TITLE
Refactor SettingsViewModel and enhance service protocols for concurrency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,3 +260,23 @@ gh issue close <number> --repo jbcrane13/NetMonitor-2.0 --comment "Done: <summar
 - ❌ Do NOT use `bd` / beads
 - ❌ Do NOT create markdown TODO lists
 
+## Activity — 2026-05-13
+- (no commits)
+
+
+## Activity — 2026-05-14
+- 52d744c refactor: centralize RSSI/quality color helpers in NetMonitorCore (#205)
+- 5489f36 chore(concurrency): drop redundant @unchecked Sendable / nonisolated(unsafe) (#210)
+- 7692945 chore: add Sendable to remaining service protocols (#206)
+- bea2191 fix(settings): convert SettingsViewModel computed get/set to stored properties (#201, #225)
+- 30c1017 feat(swiftdata): scaffold SchemaMigrationPlan (#208)
+- ec0ad19 perf(swiftdata): cap unbounded @Query reads with fetchLimit (#207)
+- ee61baf perf(scan): reuse shared queue in quickPortScan (#203)
+- 7a6ea0d chore: delete 3 dead protocols/types (#204)
+- 8ddd1e7 fix: resolve 10 SwiftLint violations from PR #226 arch-review/p1-batch
+- b42f44a Initial plan
+- 9d91ec4 refactor(heatmap): extract HeatmapFileManager + HeatmapExporter (#197 Phase 2-3)
+- 388c981 refactor(heatmap): init-inject service + delete dead polling (#197 Phase 1)
+- 30fd109 perf(scan): cap probe fanout and stop ConnectionBudget overrun (#194, #195)
+- 4b26ad7 refactor: fix three DIP/LSP violations in ViewModels (#196)
+- 1e79ec1 feat(intents): return values + dialog from iOS App Intents (#199)

--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 		0203A45AF57DA6D9B5EDF5F5 /* ISPLookupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceTests.swift; sourceTree = "<group>"; };
 		02D429D7F12642A26F1D2045 /* WHOISToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHOISToolView.swift; sourceTree = "<group>"; };
 		03EFF7191F7CE4A05EB616BE /* NewFeaturesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeaturesUITests.swift; sourceTree = "<group>"; };
-		040158ED31B51401B56621DB /* NetMonitor-iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "NetMonitor-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		040158ED31B51401B56621DB /* NetMonitor-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NetMonitor-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		04BDC838230764B6AA69A835 /* VPNInfoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoUITests.swift; sourceTree = "<group>"; };
 		04C7FA2561E26185AE834BE0 /* NetworkHealthScoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHealthScoreViewModel.swift; sourceTree = "<group>"; };
 		04EA4B2B980CA11E3A52CE1C /* VPNInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoView.swift; sourceTree = "<group>"; };
@@ -2474,6 +2474,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.netmonitor.NetMonitor;
 				SDKROOT = macosx;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2551,6 +2552,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.netmonitor.NetMonitor;
 				SDKROOT = macosx;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2735,11 +2737,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 32XZRDTGK3;
 				INFOPLIST_FILE = "NetMonitor-iOS/Resources/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "NetMonitor Mobile";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor;
 				SDKROOT = iphoneos;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2757,11 +2762,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 32XZRDTGK3;
 				INFOPLIST_FILE = "NetMonitor-iOS/Resources/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "NetMonitor Mobile";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor;
 				SDKROOT = iphoneos;
 				SWIFT_STRICT_CONCURRENCY = complete;

--- a/NetMonitor-iOS/App/AppEnvironment.swift
+++ b/NetMonitor-iOS/App/AppEnvironment.swift
@@ -1,0 +1,85 @@
+import Foundation
+import NetMonitorCore
+
+// MARK: - AppEnvironment
+
+/// Composition root for the iOS target. Holds references to the foundational
+/// services that root ViewModels depend on so they can be wired explicitly
+/// from `@main` instead of via scattered `Service.shared` defaults inside VM
+/// init signatures.
+///
+/// **Migration pattern.** Root views read this from `@Environment`:
+/// ```swift
+/// @Environment(AppEnvironment.self) private var env
+/// @State private var viewModel: DashboardViewModel
+/// init(env: AppEnvironment) {
+///     _viewModel = State(initialValue: DashboardViewModel(
+///         networkMonitor: env.networkMonitor,
+///         deviceDiscoveryService: env.deviceDiscovery,
+///         ...
+///     ))
+/// }
+/// ```
+///
+/// VM init signatures keep their existing `Service.shared` defaults during the
+/// migration so tests and child views aren't broken. Once every root view is
+/// migrated, those defaults can be removed in a follow-up.
+@MainActor
+@Observable
+final class AppEnvironment {
+
+    // MARK: - Services
+
+    let networkMonitor: any NetworkMonitorServiceProtocol
+    let deviceDiscovery: any DeviceDiscoveryServiceProtocol
+    let macConnection: any MacConnectionServiceProtocol
+    let publicIP: any PublicIPServiceProtocol
+    let wifiInfo: any WiFiInfoServiceProtocol
+    let targetManager: TargetManager
+    let activityLog: ToolActivityLog
+    let eventService: NetworkEventService
+    let scanScheduler: any ScanSchedulerServiceProtocol
+
+    // MARK: - Init
+
+    init(
+        networkMonitor: any NetworkMonitorServiceProtocol,
+        deviceDiscovery: any DeviceDiscoveryServiceProtocol,
+        macConnection: any MacConnectionServiceProtocol,
+        publicIP: any PublicIPServiceProtocol,
+        wifiInfo: any WiFiInfoServiceProtocol,
+        targetManager: TargetManager,
+        activityLog: ToolActivityLog,
+        eventService: NetworkEventService,
+        scanScheduler: any ScanSchedulerServiceProtocol
+    ) {
+        self.networkMonitor = networkMonitor
+        self.deviceDiscovery = deviceDiscovery
+        self.macConnection = macConnection
+        self.publicIP = publicIP
+        self.wifiInfo = wifiInfo
+        self.targetManager = targetManager
+        self.activityLog = activityLog
+        self.eventService = eventService
+        self.scanScheduler = scanScheduler
+    }
+
+    // MARK: - Factories
+
+    /// Production wiring. Uses the existing `*.shared` instances so services
+    /// shared with `@main` lifecycle hooks (`EventListenerService`,
+    /// `BackgroundTaskService`, etc.) keep observing the same state.
+    static func live() -> AppEnvironment {
+        AppEnvironment(
+            networkMonitor: NetworkMonitorService.shared,
+            deviceDiscovery: DeviceDiscoveryService.shared,
+            macConnection: MacConnectionService.shared,
+            publicIP: PublicIPService(),
+            wifiInfo: WiFiInfoService(),
+            targetManager: TargetManager.shared,
+            activityLog: ToolActivityLog.shared,
+            eventService: NetworkEventService.shared,
+            scanScheduler: ScanSchedulerService.shared
+        )
+    }
+}

--- a/NetMonitor-iOS/App/NetmonitorApp.swift
+++ b/NetMonitor-iOS/App/NetmonitorApp.swift
@@ -10,6 +10,7 @@ struct NetmonitorApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var showOnboarding = false
     @State private var deepLinkRouter = DeepLinkRouter()
+    @State private var environment: AppEnvironment = .live()
 
     private static var isUITesting: Bool {
         let args = ProcessInfo.processInfo.arguments
@@ -62,6 +63,7 @@ struct NetmonitorApp: App {
             ContentView()
                 .preferredColorScheme(resolvedColorScheme)
                 .accessibilityIdentifier("screen_main")
+                .environment(environment)
                 .environment(deepLinkRouter)
                 .onOpenURL { url in
                     deepLinkRouter.handle(url: url)

--- a/NetMonitor-iOS/Navigation/AppDestination.swift
+++ b/NetMonitor-iOS/Navigation/AppDestination.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+// MARK: - AppDestination
+
+/// Typed navigation destinations for the iOS app's `NavigationStack` hierarchy.
+///
+/// Standardizes value-based routing across the Dashboard, Devices, and
+/// Network Map tabs. Adding a new destination is a four-step process:
+/// 1. Add a case here.
+/// 2. Add the corresponding `case` in ``AppDestinationModifier``.
+/// 3. Replace the legacy `NavigationLink(destination:)` at the call site with
+///    `NavigationLink(value: AppDestination.<case>)`.
+/// 4. Make sure the originating `NavigationStack` has `.appDestinations()`
+///    installed on its root content.
+enum AppDestination: Hashable {
+    case deviceDetail(ipAddress: String)
+    case ping(host: String)
+    case portScanner(host: String)
+    case dnsLookup(domain: String)
+    case wakeOnLAN(mac: String)
+    case speedTest
+    case heatmapSurvey
+}
+
+// MARK: - View Modifier
+
+private struct AppDestinationModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.navigationDestination(for: AppDestination.self) { destination in
+            switch destination {
+            case .deviceDetail(let ip):
+                DeviceDetailView(ipAddress: ip)
+            case .ping(let host):
+                PingToolView(initialHost: host)
+            case .portScanner(let host):
+                PortScannerToolView(initialHost: host)
+            case .dnsLookup(let domain):
+                DNSLookupToolView(initialDomain: domain)
+            case .wakeOnLAN(let mac):
+                WakeOnLANToolView(initialMacAddress: mac)
+            case .speedTest:
+                SpeedTestToolView()
+            case .heatmapSurvey:
+                HeatmapSurveyView()
+            }
+        }
+    }
+}
+
+extension View {
+    /// Registers the canonical ``AppDestination`` map on this view's enclosing
+    /// `NavigationStack`. Apply once at the root of every tab that uses
+    /// value-based `NavigationLink(value:)` to ``AppDestination``.
+    func appDestinations() -> some View {
+        modifier(AppDestinationModifier())
+    }
+}

--- a/NetMonitor-iOS/Platform/HeatmapExporter.swift
+++ b/NetMonitor-iOS/Platform/HeatmapExporter.swift
@@ -12,17 +12,6 @@ import UIKit
 /// no longer mixes survey state with Core Graphics rendering.
 struct HeatmapExporter {
 
-    /// RGBA color for a measurement dot at the given RSSI. Mirrors the
-    /// in-canvas color thresholds shown in the live heatmap.
-    static func rssiColor(_ rssi: Int) -> UIColor {
-        switch rssi {
-        case -50...0: .systemGreen
-        case -60 ..< -50: .systemYellow
-        case -70 ..< -60: .systemOrange
-        default: .systemRed
-        }
-    }
-
     /// Renders the composite export image. Returns `nil` if either the floor
     /// plan or its image data is missing.
     func renderImage(
@@ -51,7 +40,7 @@ struct HeatmapExporter {
             for point in points {
                 let x = point.floorPlanX * canvasSize.width
                 let y = point.floorPlanY * canvasSize.height
-                let color = Self.rssiColor(point.rssi)
+                let color = RSSIQuality(rssi: point.rssi).uiColor
                 let dotRadius: CGFloat = 6
 
                 let glowRect = CGRect(

--- a/NetMonitor-iOS/Platform/IOSHeatmapService.swift
+++ b/NetMonitor-iOS/Platform/IOSHeatmapService.swift
@@ -13,13 +13,13 @@ import NetMonitorCore
 /// See `docs/iOS-WiFi-Heatmap-Spec.md` sections 2, 4, 7 for design rationale.
 @MainActor
 @Observable
-final class IOSHeatmapService: HeatmapServiceProtocol, @unchecked Sendable {
+final class IOSHeatmapService: HeatmapServiceProtocol {
 
     // MARK: - Dependencies
 
     private let wifiInfoService: any WiFiInfoServiceProtocol
     private let shortcutsProvider: ShortcutsWiFiProvider
-    nonisolated(unsafe) private let speedTestService: any SpeedTestServiceProtocol
+    private let speedTestService: any SpeedTestServiceProtocol
     private let pingService: any PingServiceProtocol
 
     /// Gateway host for latency probes during active measurements.
@@ -118,7 +118,7 @@ final class IOSHeatmapService: HeatmapServiceProtocol, @unchecked Sendable {
 
     // MARK: - Speed Test Bridge
 
-    nonisolated private func runSpeedTest() async throws -> SpeedTestData {
+    private func runSpeedTest() async throws -> SpeedTestData {
         try await speedTestService.startTest()
     }
 

--- a/NetMonitor-iOS/Platform/RSSIQuality+UIColor.swift
+++ b/NetMonitor-iOS/Platform/RSSIQuality+UIColor.swift
@@ -1,0 +1,15 @@
+import NetMonitorCore
+import UIKit
+
+extension RSSIQuality {
+    /// `UIColor` projection for `UIGraphicsImageRenderer` / `CGContext`
+    /// consumers (heatmap export, dot overlay drawing).
+    var uiColor: UIColor {
+        switch self {
+        case .excellent: .systemGreen
+        case .good: .systemYellow
+        case .fair: .systemOrange
+        case .weak: .systemRed
+        }
+    }
+}

--- a/NetMonitor-iOS/Platform/ShortcutsWiFiProvider.swift
+++ b/NetMonitor-iOS/Platform/ShortcutsWiFiProvider.swift
@@ -32,7 +32,7 @@ struct ShortcutsWiFiReading: Codable {
 /// See `docs/iOS-WiFi-Heatmap-Spec.md` for design details.
 @MainActor
 @Observable
-final class ShortcutsWiFiProvider: @unchecked Sendable {
+final class ShortcutsWiFiProvider {
 
     /// Whether the companion Shortcut appears to be installed and working.
     private(set) var isAvailable: Bool = false

--- a/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
@@ -521,23 +521,4 @@ final class HeatmapSurveyViewModel {
         return exporter.exportProjectFile(project: project, fileManager: fileManager)
     }
 
-    // MARK: - Helpers
-
-    func rssiColor(_ rssi: Int) -> UIColor {
-        switch rssi {
-        case -50...0: .systemGreen
-        case -60 ..< -50: .systemYellow
-        case -70 ..< -60: .systemOrange
-        default: .systemRed
-        }
-    }
-
-    func qualityLabel(_ rssi: Int) -> String {
-        switch rssi {
-        case -50...0: "Excellent"
-        case -60 ..< -50: "Good"
-        case -70 ..< -60: "Fair"
-        default: "Weak"
-        }
-    }
 }

--- a/NetMonitor-iOS/ViewModels/SettingsViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/SettingsViewModel.swift
@@ -7,86 +7,79 @@ import os
 @MainActor
 @Observable
 final class SettingsViewModel {
-    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.blakemiller.netmonitor", category: "SettingsViewModel")
-    // MARK: - Network Tools Settings
-    // Use UserDefaults directly since @AppStorage conflicts with @Observable
     private let defaults = UserDefaults.standard
 
+    // MARK: - Network Tools Settings
+
     var defaultPingCount: Int {
-        get { defaults.object(forKey: AppSettings.Keys.defaultPingCount) as? Int ?? 4 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.defaultPingCount) }
+        didSet { defaults.set(defaultPingCount, forKey: AppSettings.Keys.defaultPingCount) }
     }
 
     var pingTimeout: Double {
-        get { defaults.object(forKey: AppSettings.Keys.pingTimeout) as? Double ?? 5.0 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.pingTimeout) }
+        didSet { defaults.set(pingTimeout, forKey: AppSettings.Keys.pingTimeout) }
     }
 
     var portScanTimeout: Double {
-        get { defaults.object(forKey: AppSettings.Keys.portScanTimeout) as? Double ?? 2.0 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.portScanTimeout) }
+        didSet { defaults.set(portScanTimeout, forKey: AppSettings.Keys.portScanTimeout) }
     }
 
     var dnsServer: String {
-        get { defaults.string(forKey: AppSettings.Keys.dnsServer) ?? "" }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.dnsServer) }
+        didSet { defaults.set(dnsServer, forKey: AppSettings.Keys.dnsServer) }
     }
 
     // MARK: - Data Settings
+
     var dataRetentionDays: Int {
-        get { defaults.object(forKey: AppSettings.Keys.dataRetentionDays) as? Int ?? 30 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.dataRetentionDays) }
+        didSet { defaults.set(dataRetentionDays, forKey: AppSettings.Keys.dataRetentionDays) }
     }
 
     var showDetailedResults: Bool {
-        get { defaults.object(forKey: AppSettings.Keys.showDetailedResults) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.showDetailedResults) }
+        didSet { defaults.set(showDetailedResults, forKey: AppSettings.Keys.showDetailedResults) }
     }
 
     // MARK: - Monitoring Settings
+
     var autoRefreshInterval: Int {
-        get { defaults.object(forKey: AppSettings.Keys.autoRefreshInterval) as? Int ?? 60 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.autoRefreshInterval) }
+        didSet { defaults.set(autoRefreshInterval, forKey: AppSettings.Keys.autoRefreshInterval) }
     }
 
     var backgroundRefreshEnabled: Bool {
-        get { defaults.object(forKey: AppSettings.Keys.backgroundRefreshEnabled) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.backgroundRefreshEnabled) }
+        didSet { defaults.set(backgroundRefreshEnabled, forKey: AppSettings.Keys.backgroundRefreshEnabled) }
     }
 
     // MARK: - Notification Settings
+
     var targetDownAlertEnabled: Bool {
-        get { defaults.object(forKey: AppSettings.Keys.targetDownAlertEnabled) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.targetDownAlertEnabled) }
+        didSet { defaults.set(targetDownAlertEnabled, forKey: AppSettings.Keys.targetDownAlertEnabled) }
     }
 
     var highLatencyAlertEnabled: Bool {
-        get { defaults.object(forKey: AppSettings.Keys.highLatencyAlertEnabled) as? Bool ?? false }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.highLatencyAlertEnabled) }
+        didSet { defaults.set(highLatencyAlertEnabled, forKey: AppSettings.Keys.highLatencyAlertEnabled) }
     }
 
     var highLatencyThreshold: Int {
-        get { defaults.object(forKey: AppSettings.Keys.highLatencyThreshold) as? Int ?? 100 }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.highLatencyThreshold) }
+        didSet { defaults.set(highLatencyThreshold, forKey: AppSettings.Keys.highLatencyThreshold) }
     }
 
     var newDeviceAlertEnabled: Bool {
-        get { defaults.object(forKey: AppSettings.Keys.newDeviceAlertEnabled) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.newDeviceAlertEnabled) }
+        didSet { defaults.set(newDeviceAlertEnabled, forKey: AppSettings.Keys.newDeviceAlertEnabled) }
     }
 
     // MARK: - Appearance Settings
+
     var selectedTheme: String {
-        get { defaults.string(forKey: AppSettings.Keys.selectedTheme) ?? "system" }
-        set { defaults.set(newValue, forKey: AppSettings.Keys.selectedTheme) }
+        didSet { defaults.set(selectedTheme, forKey: AppSettings.Keys.selectedTheme) }
     }
 
+    /// Proxied through ThemeManager.shared, which already owns its own
+    /// @Observable storage. Reading here observes ThemeManager indirectly.
     var selectedAccentColor: String {
         get { ThemeManager.shared.selectedAccentColor }
         set { ThemeManager.shared.selectedAccentColor = newValue }
     }
 
     // MARK: - App Info
+
     var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     }
@@ -102,12 +95,31 @@ final class SettingsViewModel {
     // MARK: - Cache Info
 
     var cacheSize: String {
-        let size = calculateCacheSize()
+        let size = Self.calculateCacheSize()
         return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
     }
 
     private(set) var isClearingCache: Bool = false
     private(set) var clearCacheSuccess: Bool = false
+
+    // MARK: - Init
+
+    init() {
+        let d = UserDefaults.standard
+        defaultPingCount = d.object(forKey: AppSettings.Keys.defaultPingCount) as? Int ?? 4
+        pingTimeout = d.object(forKey: AppSettings.Keys.pingTimeout) as? Double ?? 5.0
+        portScanTimeout = d.object(forKey: AppSettings.Keys.portScanTimeout) as? Double ?? 2.0
+        dnsServer = d.string(forKey: AppSettings.Keys.dnsServer) ?? ""
+        dataRetentionDays = d.object(forKey: AppSettings.Keys.dataRetentionDays) as? Int ?? 30
+        showDetailedResults = d.object(forKey: AppSettings.Keys.showDetailedResults) as? Bool ?? true
+        autoRefreshInterval = d.object(forKey: AppSettings.Keys.autoRefreshInterval) as? Int ?? 60
+        backgroundRefreshEnabled = d.object(forKey: AppSettings.Keys.backgroundRefreshEnabled) as? Bool ?? true
+        targetDownAlertEnabled = d.object(forKey: AppSettings.Keys.targetDownAlertEnabled) as? Bool ?? true
+        highLatencyAlertEnabled = d.object(forKey: AppSettings.Keys.highLatencyAlertEnabled) as? Bool ?? false
+        highLatencyThreshold = d.object(forKey: AppSettings.Keys.highLatencyThreshold) as? Int ?? 100
+        newDeviceAlertEnabled = d.object(forKey: AppSettings.Keys.newDeviceAlertEnabled) as? Bool ?? true
+        selectedTheme = d.string(forKey: AppSettings.Keys.selectedTheme) ?? "system"
+    }
 
     // MARK: - Data Management
 
@@ -121,27 +133,27 @@ final class SettingsViewModel {
         do {
             try modelContext.delete(model: ToolResult.self)
         } catch {
-            Self.logger.error("Failed to delete tool results: \(error)")
+            Logger.app.error("Failed to delete tool results: \(error)")
         }
 
         do {
             try modelContext.delete(model: SpeedTestResult.self)
         } catch {
-            Self.logger.error("Failed to delete speed test results: \(error)")
+            Logger.app.error("Failed to delete speed test results: \(error)")
         }
 
         do {
             try modelContext.save()
         } catch {
-            Self.logger.error("Failed to save after clearing history: \(error)")
+            Logger.app.error("Failed to save after clearing history: \(error)")
         }
     }
 
-    func clearAllCachedData(modelContext: ModelContext) {
+    func clearAllCachedData(modelContext: ModelContext) async {
         isClearingCache = true
         clearCacheSuccess = false
 
-        // 1. Clear all SwiftData model stores
+        // SwiftData deletions stay on MainActor — modelContext is MainActor-bound.
         let modelTypes: [any PersistentModel.Type] = [
             ToolResult.self,
             SpeedTestResult.self,
@@ -154,35 +166,31 @@ final class SettingsViewModel {
             do {
                 try modelContext.delete(model: modelType)
             } catch {
-                Self.logger.error("Failed to delete \(String(describing: modelType)): \(error)")
+                Logger.app.error("Failed to delete \(String(describing: modelType)): \(error)")
             }
         }
 
         do {
             try modelContext.save()
         } catch {
-            Self.logger.error("Failed to save after clearing data: \(error)")
+            Logger.app.error("Failed to save after clearing data: \(error)")
         }
 
-        // 2. Clear URLCache
-        URLCache.shared.removeAllCachedResponses()
-
-        // 3. Clear tmp directory
-        clearDirectory(at: FileManager.default.temporaryDirectory)
-
-        // 4. Clear Caches directory
-        if let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
-            clearDirectory(at: cachesDir)
-        }
-
-        // 5. Clear UserDefaults cache-related keys (not settings)
-        // We keep user preferences but remove cached data keys if any
+        // URLCache + file-system sweeps run on a background executor — they're
+        // sync I/O and can take noticeable time on a populated cache.
+        await Task.detached(priority: .utility) {
+            URLCache.shared.removeAllCachedResponses()
+            Self.clearDirectory(at: FileManager.default.temporaryDirectory)
+            if let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+                Self.clearDirectory(at: cachesDir)
+            }
+        }.value
 
         clearCacheSuccess = true
         isClearingCache = false
     }
 
-    private func clearDirectory(at url: URL) {
+    private static func clearDirectory(at url: URL) {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil) else { return }
         for file in contents {
@@ -190,22 +198,17 @@ final class SettingsViewModel {
         }
     }
 
-    private func calculateCacheSize() -> Int64 {
+    private static func calculateCacheSize() -> Int64 {
         var total: Int64 = 0
         let fm = FileManager.default
-
-        // tmp directory
         total += directorySize(at: fm.temporaryDirectory)
-
-        // Caches directory
         if let cachesDir = fm.urls(for: .cachesDirectory, in: .userDomainMask).first {
             total += directorySize(at: cachesDir)
         }
-
         return total
     }
 
-    private func directorySize(at url: URL) -> Int64 {
+    private static func directorySize(at url: URL) -> Int64 {
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
         var total: Int64 = 0

--- a/NetMonitor-iOS/ViewModels/WorldPingToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/WorldPingToolViewModel.swift
@@ -24,11 +24,11 @@ final class WorldPingToolViewModel {
 
     // MARK: - Dependencies
 
-    private let service: any WorldPingServiceProtocol
+    private let runner: WorldPingRunner
     private var runTask: Task<Void, Never>?
 
     init(service: any WorldPingServiceProtocol = WorldPingService()) {
-        self.service = service
+        self.runner = WorldPingRunner(service: service)
     }
 
     // MARK: - Computed
@@ -61,22 +61,14 @@ final class WorldPingToolViewModel {
         errorMessage = nil
         isRunning = true
 
-        runTask = Task {
-            let stream = await service.ping(
-                host: hostInput.trimmingCharacters(in: .whitespaces),
-                maxNodes: 20
-            )
-
-            for await result in stream {
-                guard !Task.isCancelled else { break }
-                results.append(result)
-                results.sort { ($0.latencyMs ?? Double.infinity) < ($1.latencyMs ?? Double.infinity) }
+        runTask = Task { [runner] in
+            let host = hostInput.trimmingCharacters(in: .whitespaces)
+            _ = await runner.run(host: host, maxNodes: 20) { sorted in
+                results = sorted
             }
-
             guard !Task.isCancelled else { return }
-
             if results.isEmpty {
-                errorMessage = service.lastError ?? "No results returned. Check the host address and your network connection."
+                errorMessage = runner.emptyResultsMessage()
             }
             isRunning = false
         }

--- a/NetMonitor-iOS/Views/ContentView.swift
+++ b/NetMonitor-iOS/Views/ContentView.swift
@@ -3,6 +3,7 @@ import NetMonitorCore
 import SwiftData
 
 struct ContentView: View {
+    @Environment(AppEnvironment.self) private var env
     @State private var selectedTab: Tab = .dashboard
     @State private var selectedSidebarTab: Tab? = .dashboard
     // Observe ThemeManager so the entire view tree re-renders on accent color change
@@ -66,7 +67,7 @@ struct ContentView: View {
                         .tag(Tab.tools)
                         .accessibilityIdentifier("contentView_tab_tools")
 
-                    TimelineView()
+                    TimelineView(env: env)
                         .tabItem {
                             Label(Tab.timeline.title, systemImage: Tab.timeline.icon)
                         }
@@ -207,7 +208,7 @@ struct ContentView: View {
         case .dashboard: DashboardView()
         case .map: NetworkMapView()
         case .tools: ToolsView()
-        case .timeline: TimelineView()
+        case .timeline: TimelineView(env: env)
         }
     }
 }

--- a/NetMonitor-iOS/Views/ContentView.swift
+++ b/NetMonitor-iOS/Views/ContentView.swift
@@ -215,5 +215,6 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environment(AppEnvironment.live())
         .modelContainer(for: [], inMemory: true)
 }

--- a/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
+++ b/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
@@ -17,6 +17,7 @@ struct DashboardView: View {
                         .padding(.top, Theme.Layout.smallCornerRadius)
                         .padding(.bottom, Theme.Layout.sectionSpacing)
                 }
+                .appDestinations()
                 .themedBackground()
                 .navigationTitle("Dashboard")
                 .navigationBarTitleDisplayMode(.inline)
@@ -730,7 +731,7 @@ struct SpeedTestQuickCard: View {
     private var lastResult: SpeedTestResult? { history.first }
 
     var body: some View {
-        NavigationLink(destination: SpeedTestToolView()) {
+        NavigationLink(value: AppDestination.speedTest) {
             GlassCard(padding: 14, statusGlow: Theme.Colors.info) {
                 HStack(spacing: 14) {
                     ZStack {
@@ -784,7 +785,7 @@ struct SpeedTestQuickCard: View {
 
 struct WiFiHeatmapQuickCard: View {
     var body: some View {
-        NavigationLink(destination: HeatmapSurveyView()) {
+        NavigationLink(value: AppDestination.heatmapSurvey) {
             GlassCard(padding: 14) {
                 HStack(spacing: 14) {
                     ZStack {

--- a/NetMonitor-iOS/Views/Dashboard/DeviceListView.swift
+++ b/NetMonitor-iOS/Views/Dashboard/DeviceListView.swift
@@ -97,7 +97,7 @@ struct DeviceListView: View {
                     .padding(.horizontal, Theme.Layout.screenPadding)
 
                     ForEach(sortedDevices) { device in
-                        NavigationLink(destination: DeviceDetailView(ipAddress: device.ipAddress)) {
+                        NavigationLink(value: AppDestination.deviceDetail(ipAddress: device.ipAddress)) {
                             if isProMode {
                                 proModeRow(device: device)
                             } else {

--- a/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
+++ b/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
@@ -404,7 +404,7 @@ struct DeviceDetailView: View {
 
             VStack(spacing: Theme.Layout.itemSpacing) {
                 // Ping button
-                NavigationLink(destination: PingToolView(initialHost: device.ipAddress)) {
+                NavigationLink(value: AppDestination.ping(host: device.ipAddress)) {
                     HStack {
                         Image(systemName: "antenna.radiowaves.left.and.right")
                             .foregroundStyle(Theme.Colors.accent)
@@ -426,7 +426,7 @@ struct DeviceDetailView: View {
                 Divider().background(Theme.Colors.glassBorder)
 
                 // Port Scan button
-                NavigationLink(destination: PortScannerToolView(initialHost: device.ipAddress)) {
+                NavigationLink(value: AppDestination.portScanner(host: device.ipAddress)) {
                     HStack {
                         Image(systemName: "server.rack")
                             .foregroundStyle(Theme.Colors.accent)
@@ -448,7 +448,7 @@ struct DeviceDetailView: View {
                 Divider().background(Theme.Colors.glassBorder)
 
                 // DNS Lookup button
-                NavigationLink(destination: DNSLookupToolView(initialDomain: device.ipAddress)) {
+                NavigationLink(value: AppDestination.dnsLookup(domain: device.ipAddress)) {
                     HStack {
                         Image(systemName: "globe")
                             .foregroundStyle(Theme.Colors.accent)
@@ -471,7 +471,7 @@ struct DeviceDetailView: View {
                 if device.supportsWakeOnLan {
                     Divider().background(Theme.Colors.glassBorder)
 
-                    NavigationLink(destination: WakeOnLANToolView(initialMacAddress: device.macAddress)) {
+                    NavigationLink(value: AppDestination.wakeOnLAN(mac: device.macAddress)) {
                         HStack {
                             Image(systemName: "power")
                                 .foregroundStyle(Theme.Colors.success)

--- a/NetMonitor-iOS/Views/Heatmap/HeatmapCanvasView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/HeatmapCanvasView.swift
@@ -84,7 +84,7 @@ struct HeatmapCanvasView: View {
     private func measurementDot(for point: MeasurementPoint, in imageSize: CGSize) -> some View {
         let x = point.floorPlanX * imageSize.width
         let y = point.floorPlanY * imageSize.height
-        let color = Color(uiColor: viewModel.rssiColor(point.rssi))
+        let color = RSSIQuality(rssi: point.rssi).color
 
         return ZStack {
             // Outer glow

--- a/NetMonitor-iOS/Views/Heatmap/HeatmapSurveyView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/HeatmapSurveyView.swift
@@ -279,7 +279,7 @@ extension HeatmapSurveyView {
                 if shortcutsProvider.isAvailable {
                     Image(systemName: rssiWiFiIcon(viewModel.currentRSSI))
                         .font(.caption.bold())
-                        .foregroundStyle(rssiColor(viewModel.currentRSSI))
+                        .foregroundStyle(RSSIQuality(rssi: viewModel.currentRSSI).color)
                     Text("\(viewModel.currentRSSI) dBm")
                         .font(.caption.monospacedDigit().bold())
                         .foregroundStyle(Theme.Colors.textPrimary)
@@ -476,15 +476,6 @@ extension HeatmapSurveyView {
     }
 
     // MARK: - Helpers
-
-    private func rssiColor(_ rssi: Int) -> Color {
-        switch rssi {
-        case -50...0: .green
-        case -60 ..< -50: .yellow
-        case -70 ..< -60: .orange
-        default: .red
-        }
-    }
 
     private func rssiWiFiIcon(_ rssi: Int) -> String {
         switch rssi {

--- a/NetMonitor-iOS/Views/NetworkMap/NetworkMapView.swift
+++ b/NetMonitor-iOS/Views/NetworkMap/NetworkMapView.swift
@@ -77,7 +77,7 @@ struct NetworkMapView: View {
                     } else {
                         VStack(spacing: 8) {
                             ForEach(sortedDevices) { device in
-                                NavigationLink(destination: DeviceDetailView(ipAddress: device.ipAddress)) {
+                                NavigationLink(value: AppDestination.deviceDetail(ipAddress: device.ipAddress)) {
                                     ProDeviceRow(device: device, isScanning: viewModel.isScanning)
                                 }
                                 .buttonStyle(PlainButtonStyle())
@@ -90,6 +90,7 @@ struct NetworkMapView: View {
                 .padding(.top, Theme.Layout.smallCornerRadius)
                 .padding(.bottom, Theme.Layout.sectionSpacing)
             }
+            .appDestinations()
             .themedBackground()
             .navigationTitle("Network Map")
             .accessibilityIdentifier("screen_networkMap")

--- a/NetMonitor-iOS/Views/Settings/SettingsView.swift
+++ b/NetMonitor-iOS/Views/Settings/SettingsView.swift
@@ -353,7 +353,7 @@ struct SettingsView: View {
         .alert("Clear All Cached Data", isPresented: $showingClearCacheAlert) {
             Button("Cancel", role: .cancel) {}
             Button("Clear All", role: .destructive) {
-                viewModel.clearAllCachedData(modelContext: modelContext)
+                Task { await viewModel.clearAllCachedData(modelContext: modelContext) }
             }
         } message: {
             Text("This will delete all stored data including tool results, speed tests, discovered devices, monitoring targets, and file caches. This action cannot be undone.")

--- a/NetMonitor-iOS/Views/Timeline/TimelineView.swift
+++ b/NetMonitor-iOS/Views/Timeline/TimelineView.swift
@@ -2,8 +2,12 @@ import SwiftUI
 import NetMonitorCore
 
 struct TimelineView: View {
-    @State private var viewModel = TimelineViewModel()
+    @State private var viewModel: TimelineViewModel
     @State private var showingFilterSheet = false
+
+    init(env: AppEnvironment) {
+        _viewModel = State(initialValue: TimelineViewModel(service: env.eventService))
+    }
 
     var body: some View {
         NavigationStack {
@@ -237,5 +241,5 @@ struct TimelineFilterSheet: View {
 }
 
 #Preview {
-    TimelineView()
+    TimelineView(env: .live())
 }

--- a/NetMonitor-macOS/Platform/RSSIQuality+NSColor.swift
+++ b/NetMonitor-macOS/Platform/RSSIQuality+NSColor.swift
@@ -1,0 +1,15 @@
+import AppKit
+import NetMonitorCore
+
+extension RSSIQuality {
+    /// `NSColor` projection for `NSGraphicsContext` consumers (heatmap canvas
+    /// dot overlay drawing on macOS).
+    var nsColor: NSColor {
+        switch self {
+        case .excellent: .systemGreen
+        case .good: .systemYellow
+        case .fair: .systemOrange
+        case .weak: .systemRed
+        }
+    }
+}

--- a/NetMonitor-macOS/ViewModels/WorldPingToolViewModel.swift
+++ b/NetMonitor-macOS/ViewModels/WorldPingToolViewModel.swift
@@ -17,11 +17,11 @@ final class MacWorldPingToolViewModel {
 
     // MARK: - Dependencies
 
-    private let service: any WorldPingServiceProtocol
+    private let runner: WorldPingRunner
     private var runTask: Task<Void, Never>?
 
     init(service: any WorldPingServiceProtocol = WorldPingService()) {
-        self.service = service
+        self.runner = WorldPingRunner(service: service)
     }
 
     // MARK: - Computed
@@ -46,18 +46,13 @@ final class MacWorldPingToolViewModel {
         errorMessage = nil
         isRunning = true
 
-        runTask = Task {
-            let stream = await service.ping(host: host, maxNodes: 20)
-            for await result in stream {
-                guard !Task.isCancelled else { break }
-                results.append(result)
-                results.sort { ($0.latencyMs ?? .infinity) < ($1.latencyMs ?? .infinity) }
+        runTask = Task { [runner] in
+            _ = await runner.run(host: host, maxNodes: 20) { sorted in
+                results = sorted
             }
-
             guard !Task.isCancelled else { return }
-
             if results.isEmpty {
-                errorMessage = service.lastError ?? "No results returned. Check the host and your network connection."
+                errorMessage = runner.emptyResultsMessage()
             }
             isRunning = false
         }

--- a/NetMonitor-macOS/Views/Heatmap/HeatmapCanvasNSView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/HeatmapCanvasNSView.swift
@@ -261,9 +261,9 @@ class HeatmapCanvasNS: NSView {
                 let haloRadius: CGFloat = isHovered ? 14 : 10
                 let haloRect = CGRect(x: x - haloRadius, y: y - haloRadius,
                                       width: haloRadius * 2, height: haloRadius * 2)
-                context.setFillColor(rssiColor(point.rssi).withAlphaComponent(0.3).cgColor)
+                context.setFillColor(RSSIQuality(rssi: point.rssi).nsColor.withAlphaComponent(0.3).cgColor)
                 context.fillEllipse(in: haloRect)
-                context.setStrokeColor(rssiColor(point.rssi).cgColor)
+                context.setStrokeColor(RSSIQuality(rssi: point.rssi).nsColor.cgColor)
                 context.setLineWidth(2)
                 context.strokeEllipse(in: haloRect)
             }
@@ -440,7 +440,7 @@ class HeatmapCanvasNS: NSView {
         ]
         let boldAttrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.boldSystemFont(ofSize: 11),
-            .foregroundColor: rssiColor(point.rssi)
+            .foregroundColor: RSSIQuality(rssi: point.rssi).nsColor
         ]
 
         let lineHeight: CGFloat = 14
@@ -466,7 +466,7 @@ class HeatmapCanvasNS: NSView {
         context.strokePath()
 
         // Header line: RSSI + quality
-        let header = "\(point.rssi) dBm · \(qualityLabel(point.rssi))" as NSString
+        let header = "\(point.rssi) dBm · \(RSSIQuality(rssi: point.rssi).label)" as NSString
         header.draw(at: CGPoint(x: tooltipX + padding, y: tooltipY + padding), withAttributes: boldAttrs)
 
         // Detail lines
@@ -546,24 +546,6 @@ class HeatmapCanvasNS: NSView {
             let dy = mouseLocation.y - y
             return (dx * dx + dy * dy).squareRoot() < hitRadius
         }?.id
-    }
-
-    private func rssiColor(_ rssi: Int) -> NSColor {
-        switch rssi {
-        case -50...0: .systemGreen
-        case -60 ..< -50: .systemYellow
-        case -70 ..< -60: .systemOrange
-        default: .systemRed
-        }
-    }
-
-    private func qualityLabel(_ rssi: Int) -> String {
-        switch rssi {
-        case -50...0: "Excellent"
-        case -60 ..< -50: "Good"
-        case -70 ..< -60: "Fair"
-        default: "Weak"
-        }
     }
 
     private func drawEmptyState(_ context: CGContext) {

--- a/NetMonitor-macOS/Views/Heatmap/HeatmapSidebarView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/HeatmapSidebarView.swift
@@ -87,9 +87,9 @@ struct HeatmapSidebarView: View {
             if let signal = viewModel.currentSignal {
                 Text("\(signal.rssi)")
                     .font(.system(size: 36, weight: .heavy, design: .rounded))
-                    .foregroundStyle(colorForRSSI(signal.rssi))
+                    .foregroundStyle(RSSIQuality(rssi: signal.rssi).color)
 
-                Text("dBm · \(qualityLabel(signal.rssi))")
+                Text("dBm · \(RSSIQuality(rssi: signal.rssi).label)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -220,7 +220,7 @@ struct HeatmapSidebarView: View {
                         Spacer()
                         Text("\(ap.rssi) dBm")
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(colorForRSSI(ap.rssi))
+                            .foregroundStyle(RSSIQuality(rssi: ap.rssi).color)
                     }
                     .contentShape(Rectangle())
                     .onTapGesture {
@@ -362,27 +362,10 @@ struct HeatmapSidebarView: View {
         HStack(spacing: 2) {
             ForEach(0..<5) { i in
                 RoundedRectangle(cornerRadius: 1)
-                    .fill(rssi >= -90 + i * 12 ? colorForRSSI(rssi) : Color.gray.opacity(0.3))
+                    .fill(rssi >= -90 + i * 12 ? RSSIQuality(rssi: rssi).color : Color.gray.opacity(0.3))
                     .frame(width: 6, height: CGFloat(6 + i * 3))
             }
         }
     }
 
-    private func colorForRSSI(_ rssi: Int) -> Color {
-        switch rssi {
-        case -50...0: .green
-        case -60 ..< -50: .yellow
-        case -70 ..< -60: .orange
-        default: .red
-        }
-    }
-
-    private func qualityLabel(_ rssi: Int) -> String {
-        switch rssi {
-        case -50...0: "Excellent"
-        case -60 ..< -50: "Good"
-        case -70 ..< -60: "Fair"
-        default: "Weak"
-        }
-    }
 }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/RSSIQuality.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/RSSIQuality.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftUI
+
+/// Bucketing of a Wi-Fi RSSI value into a small set of human-readable quality
+/// tiers. Centralizes the threshold ladder (`-50/-60/-70`) that was previously
+/// duplicated across five sites in the iOS and macOS targets.
+///
+/// `label` and `color` (SwiftUI) live here. Platform-specific colour
+/// projections — `UIColor` on iOS, `NSColor` on macOS — are added by extension
+/// in each app target so this module stays free of UIKit/AppKit.
+public enum RSSIQuality: Sendable, CaseIterable {
+    case excellent
+    case good
+    case fair
+    case weak
+
+    public init(rssi: Int) {
+        switch rssi {
+        case -50...0: self = .excellent
+        case -60..<(-50): self = .good
+        case -70..<(-60): self = .fair
+        default: self = .weak
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .excellent: "Excellent"
+        case .good: "Good"
+        case .fair: "Fair"
+        case .weak: "Weak"
+        }
+    }
+
+    public var color: Color {
+        switch self {
+        case .excellent: .green
+        case .good: .yellow
+        case .fair: .orange
+        case .weak: .red
+        }
+    }
+}

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
@@ -76,7 +76,7 @@ public protocol PortScannerServiceProtocol: AnyObject, Sendable {
 }
 
 /// Protocol for DNS lookup operations.
-public protocol DNSLookupServiceProtocol: AnyObject {
+public protocol DNSLookupServiceProtocol: AnyObject, Sendable {
     @MainActor var isLoading: Bool { get }
     @MainActor var lastError: String? { get }
     @MainActor func lookup(domain: String, recordType: DNSRecordType, server: String?) async -> DNSQueryResult?
@@ -88,7 +88,7 @@ public protocol WHOISServiceProtocol: AnyObject, Sendable {
 }
 
 /// Protocol for Wake on LAN operations.
-public protocol WakeOnLANServiceProtocol {
+public protocol WakeOnLANServiceProtocol: AnyObject, Sendable {
     @MainActor var isSending: Bool { get }
     @MainActor var lastResult: WakeOnLANResult? { get }
     @MainActor var lastError: String? { get }
@@ -115,7 +115,7 @@ public protocol SpeedTestServiceProtocol: Sendable {
 }
 
 /// Protocol for network path monitoring.
-public protocol NetworkMonitorServiceProtocol {
+public protocol NetworkMonitorServiceProtocol: AnyObject, Sendable {
     @MainActor var isConnected: Bool { get }
     @MainActor var connectionType: ConnectionType { get }
     @MainActor var isExpensive: Bool { get }
@@ -139,7 +139,7 @@ public protocol DeviceDiscoveryServiceProtocol: AnyObject, Sendable {
 }
 
 /// Protocol for default gateway detection.
-public protocol GatewayServiceProtocol {
+public protocol GatewayServiceProtocol: AnyObject, Sendable {
     @MainActor var gateway: GatewayInfo? { get }
     @MainActor var isLoading: Bool { get }
     /// Rolling history of recent gateway latency measurements (newest first).

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingRunner.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/WorldPingRunner.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - WorldPingRunner
+
+/// Encapsulates the duplicated run-and-accumulate loop that was previously
+/// inlined in both `WorldPingToolViewModel` (iOS) and
+/// `MacWorldPingToolViewModel` (macOS). Owns the `WorldPingServiceProtocol`
+/// reference and the result-sorting policy; callers own the `Task` lifecycle
+/// and the observable result array.
+///
+/// The runner is `Sendable` so it can be stored on `@MainActor @Observable`
+/// VMs without isolation friction.
+public struct WorldPingRunner: Sendable {
+    public let service: any WorldPingServiceProtocol
+
+    public init(service: any WorldPingServiceProtocol) {
+        self.service = service
+    }
+
+    /// Streams the service's results, sorting the accumulator by ascending
+    /// latency after each yield. Calls `onUpdate` on the @MainActor with the
+    /// current sorted snapshot so the VM's `@Observable` array assignment
+    /// triggers a SwiftUI redraw.
+    ///
+    /// Returns the final accumulated results, or a partial accumulation if
+    /// the task is cancelled. Callers should check `Task.isCancelled` after
+    /// `await` to decide whether to apply terminal state.
+    @MainActor
+    public func run(
+        host: String,
+        maxNodes: Int = 20,
+        onUpdate: @MainActor (_ results: [WorldPingLocationResult]) -> Void
+    ) async -> [WorldPingLocationResult] {
+        var accumulated: [WorldPingLocationResult] = []
+        let stream = await service.ping(host: host, maxNodes: maxNodes)
+        for await result in stream {
+            guard !Task.isCancelled else { break }
+            accumulated.append(result)
+            accumulated.sort { ($0.latencyMs ?? .infinity) < ($1.latencyMs ?? .infinity) }
+            onUpdate(accumulated)
+        }
+        return accumulated
+    }
+
+    /// Convenience: pulls the trimmed `lastError` off the underlying service
+    /// or returns a default empty-results message. Used by VMs when the
+    /// stream finishes with no results.
+    public func emptyResultsMessage(default: String = "No results returned. Check the host and your network connection.") -> String {
+        service.lastError ?? `default`
+    }
+}

--- a/Tests/NetMonitor-iOSTests/SettingsViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/SettingsViewModelTests.swift
@@ -240,23 +240,23 @@ struct SettingsViewModelDataManagementTests {
         #expect(remaining.isEmpty)
     }
 
-    @Test func clearAllCachedDataSetsClearCacheSuccessTrue() throws {
+    @Test func clearAllCachedDataSetsClearCacheSuccessTrue() async throws {
         let (_, context) = try makeInMemoryStore()
         let vm = SettingsViewModel()
 
-        vm.clearAllCachedData(modelContext: context)
+        await vm.clearAllCachedData(modelContext: context)
 
         #expect(vm.clearCacheSuccess == true)
         #expect(vm.isClearingCache == false)
     }
 
-    @Test func clearAllCachedDataDeletesAllModelTypes() throws {
+    @Test func clearAllCachedDataDeletesAllModelTypes() async throws {
         let (_, context) = try makeInMemoryStore()
         context.insert(ToolResult(toolType: .ping, target: "8.8.8.8", success: true, summary: "OK"))
         context.insert(LocalDevice(ipAddress: "192.168.1.1", macAddress: "AA:BB"))
         try context.save()
 
-        SettingsViewModel().clearAllCachedData(modelContext: context)
+        await SettingsViewModel().clearAllCachedData(modelContext: context)
 
         #expect(try context.fetch(FetchDescriptor<ToolResult>()).isEmpty)
         #expect(try context.fetch(FetchDescriptor<LocalDevice>()).isEmpty)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
