### PR TITLE
Enhance architecture with batch wave 2 and composition improvements

### DIFF
--- a/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
@@ -521,4 +521,9 @@ final class HeatmapSurveyViewModel {
         return exporter.exportProjectFile(project: project, fileManager: fileManager)
     }
 
+    /// Compatibility wrapper for existing call sites and tests.
+    func qualityLabel(_ rssi: Int) -> String {
+        RSSIQuality(rssi: rssi).label
+    }
+
 }


### PR DESCRIPTION
This pull request adds a compatibility wrapper method to the `HeatmapSurveyViewModel` class in order to maintain support for existing call sites and tests.

- Compatibility:
  * Added a `qualityLabel(_:)` method to `HeatmapSurveyViewModel` as a wrapper for obtaining the RSSI quality label, ensuring backward compatibility with existing code and tests.## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
