### PR TITLE
Arch review/p2 composition and routing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,7 @@ excluded:
   - Packages/**/.build
   - Packages/**/checkouts
   - .worktrees
+  - .claude/worktrees
   - "**/*.xcodeproj"
   - Tests
   - Packages/NetMonitorCore/Tests

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>teamID</key>
+    <string>32XZRDTGK3</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		16B26C579C268C19A73FD6C2 /* TimelineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B00EA123A802E6A56E6BE02 /* TimelineUITests.swift */; };
 		16BEA491C1FAAD14D7EADC52 /* SubnetCalculatorToolViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F859F6CEAF0904E53EAF93 /* SubnetCalculatorToolViewModelTests.swift */; };
 		1712B0E6620F2F329C079F1C /* AppStoreScreenshotUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2241FEC08B240B2D5CBDAE5 /* AppStoreScreenshotUITests.swift */; };
+		176CC089BB3E6B2AE3BDFA31 /* RSSIQuality+NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26335B5AC0E45923FD2B40C7 /* RSSIQuality+NSColor.swift */; };
 		17B04E6855991A4EF847A581 /* DevicesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE319B17E4D376A2BCF4D485 /* DevicesUITests.swift */; };
 		189A8D6C0EF1A41FB9AB2521 /* NetworkHealthScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E195D25F65C467973A5F31FA /* NetworkHealthScoreView.swift */; };
 		190838A3E12806448FE26392 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8650B3D9EC5CDB844E93B843 /* SettingsView.swift */; };
@@ -105,6 +106,7 @@
 		3B9758EFDB57F43C0643E94B /* NetworkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3689C1E4EA6FD859AF5B7F0C /* NetworkDetailView.swift */; };
 		3C0465890341EF643095BBF9 /* ToolRunButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EED0AE800C74EEAF77F9DF5 /* ToolRunButton.swift */; };
 		3C62E16E5D47E754A344DC1F /* WorldPingToolViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D78F7ADDB4090CCE4EEA2 /* WorldPingToolViewModel.swift */; };
+		3D0555455D57DBBBE7619889 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879D3BC07FD7C06C5AB3A37 /* AppEnvironment.swift */; };
 		3DA19906C6D3C7D6712626F6 /* GatewayLatencyFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41847F6534432C141EBCB89 /* GatewayLatencyFallbackTests.swift */; };
 		3DC5C0E092864EB34F5FB283 /* AddTargetSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA56070D9F03D65EA3EC10D /* AddTargetSheet.swift */; };
 		3DCD3D682BC9AEF8B4C0AA09 /* SchemaV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2FB79A16ADB85CC5B45664 /* SchemaV1.swift */; };
@@ -299,6 +301,7 @@
 		AAA4FFC237B612D2669BD194 /* MacConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2224DE47C4DB83B5ED7E474B /* MacConnectionService.swift */; };
 		AAF35FC2E47B9088503B00FF /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902FDF34A4DD511DF5326DA1 /* Logging.swift */; };
 		AB3113830C51BB6EE21638C4 /* GeoTraceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5464A172BCA9FDBB6E85362B /* GeoTraceUITests.swift */; };
+		ABDED888167044934B94AA33 /* RSSIQuality+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA5B05C35E3A8A411A54699 /* RSSIQuality+UIColor.swift */; };
 		AC7119870BA0A73532C4EC90 /* NetworkHealthScoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C7FA2561E26185AE834BE0 /* NetworkHealthScoreViewModel.swift */; };
 		ACC95524FDB6D069334A6DE6 /* MacNetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DE27495CAFD0EF97D63222 /* MacNetworkMonitor.swift */; };
 		ACC9E2AAC225ACE46FFA7690 /* NetworkScanKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8887BED82A4320C8CAFBA574 /* NetworkScanKit */; };
@@ -333,6 +336,7 @@
 		C5187D03FCD8F2551064E6FD /* GeoTraceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6265B72D55BCAD7A4DF3AA20 /* GeoTraceView.swift */; };
 		C519A0D9C77688C33220A4C1 /* BonjourBrowserToolUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70771A36E2D8C3A8C4690FD2 /* BonjourBrowserToolUITests.swift */; };
 		C557FD376DC02C0FFF46E49A /* PingToolViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188CE56C7F99450209487467 /* PingToolViewModelTests.swift */; };
+		C56023FDB9FD3C9ADBD9BB18 /* AppDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E708B64D2ED3CF952B4902 /* AppDestination.swift */; };
 		C65FFAD3A3006F68D3D8F02D /* ScheduledScanViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE55D064CFB3CE51457346A /* ScheduledScanViewModelTests.swift */; };
 		C747D63AC6BC9E495ACB672B /* BlueprintBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDA6904D162A74575EE323F /* BlueprintBuilder.swift */; };
 		C7983048A8627C4384B6355D /* WiFiReadingBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0F99A463B96E0387EA80D /* WiFiReadingBridgeTests.swift */; };
@@ -481,7 +485,7 @@
 		0203A45AF57DA6D9B5EDF5F5 /* ISPLookupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceTests.swift; sourceTree = "<group>"; };
 		02D429D7F12642A26F1D2045 /* WHOISToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHOISToolView.swift; sourceTree = "<group>"; };
 		03EFF7191F7CE4A05EB616BE /* NewFeaturesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeaturesUITests.swift; sourceTree = "<group>"; };
-		040158ED31B51401B56621DB /* NetMonitor-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NetMonitor-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		040158ED31B51401B56621DB /* NetMonitor-iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "NetMonitor-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		04BDC838230764B6AA69A835 /* VPNInfoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoUITests.swift; sourceTree = "<group>"; };
 		04C7FA2561E26185AE834BE0 /* NetworkHealthScoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHealthScoreViewModel.swift; sourceTree = "<group>"; };
 		04EA4B2B980CA11E3A52CE1C /* VPNInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoView.swift; sourceTree = "<group>"; };
@@ -542,6 +546,7 @@
 		22C146A39287FFF5DD38F8C3 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		2318C9AFCEE31C60D3E14516 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		247C2718CDBD3187540F4A47 /* SpeedTestIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestIntent.swift; sourceTree = "<group>"; };
+		26335B5AC0E45923FD2B40C7 /* RSSIQuality+NSColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSSIQuality+NSColor.swift"; sourceTree = "<group>"; };
 		273DFEA060BE77C6F58BE72B /* AppIntentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		28840E366E12B65E3AAD7F2E /* ToolInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolInputField.swift; sourceTree = "<group>"; };
 		2926D7C25A7E15A889609FFE /* FunctionalSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalSmokeTests.swift; sourceTree = "<group>"; };
@@ -705,6 +710,7 @@
 		87D31E0912E4D4C961789D8F /* DeviceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListView.swift; sourceTree = "<group>"; };
 		87D55E3AA39B425C3CEEC358 /* MacOSInteractionFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSInteractionFlowUITests.swift; sourceTree = "<group>"; };
 		884331E906096344FF4F5D46 /* PostScanRefinementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostScanRefinementTests.swift; sourceTree = "<group>"; };
+		8879D3BC07FD7C06C5AB3A37 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		89FEF8C98AA01BED84B73181 /* SubnetCalculatorToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubnetCalculatorToolView.swift; sourceTree = "<group>"; };
 		8BB0F99A463B96E0387EA80D /* WiFiReadingBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiReadingBridgeTests.swift; sourceTree = "<group>"; };
 		8C02C598E7B86F34E4C55714 /* PingToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingToolView.swift; sourceTree = "<group>"; };
@@ -771,6 +777,7 @@
 		B0AFB80A0447C601E26B6416 /* WiFiBandVersionCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiBandVersionCompatTests.swift; sourceTree = "<group>"; };
 		B0BC4A7335A7D1D27798D9F3 /* PortScannerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerServiceTests.swift; sourceTree = "<group>"; };
 		B0BED56FCE2CE5CDD9B8A403 /* SaveWiFiReadingIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveWiFiReadingIntentTests.swift; sourceTree = "<group>"; };
+		B0E708B64D2ED3CF952B4902 /* AppDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDestination.swift; sourceTree = "<group>"; };
 		B1B57C01900DCE5F4E89B517 /* SpeedTestServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		B2241FEC08B240B2D5CBDAE5 /* AppStoreScreenshotUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreScreenshotUITests.swift; sourceTree = "<group>"; };
 		B301F7F03474A826032059DB /* WorldPingToolViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingToolViewModelTests.swift; sourceTree = "<group>"; };
@@ -873,6 +880,7 @@
 		EA2FB79A16ADB85CC5B45664 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
 		EA561BD6AF240A98038ED27A /* ToolResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolResultRow.swift; sourceTree = "<group>"; };
 		EA9F6FEE74897775AB8E270F /* BlueprintErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintErrorHandlingTests.swift; sourceTree = "<group>"; };
+		EAA5B05C35E3A8A411A54699 /* RSSIQuality+UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSSIQuality+UIColor.swift"; sourceTree = "<group>"; };
 		EB1FBBC1DD3CF85853D633F6 /* DeviceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDetailView.swift; sourceTree = "<group>"; };
 		EB509C8F5C1662B03D2298B0 /* PingToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingToolUITests.swift; sourceTree = "<group>"; };
 		EB83C8CE997BFCDD36C53D6F /* ScheduledScanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledScanViewModel.swift; sourceTree = "<group>"; };
@@ -1062,6 +1070,7 @@
 				603D57D4202F475E3E7CB108 /* PDFReportGenerator.swift */,
 				F5FB4FB0D3D64F7724CB521D /* PublicIPService.swift */,
 				08548A1C1E2724BA55054DBB /* RateAppService.swift */,
+				EAA5B05C35E3A8A411A54699 /* RSSIQuality+UIColor.swift */,
 				1E4BCAE06DD86235A4D27BA1 /* SharedServices.swift */,
 				E719E41F16DE685161031931 /* ShortcutsWiFiProvider.swift */,
 				1280084A1B0D74730547A6EB /* TargetManager.swift */,
@@ -1081,6 +1090,14 @@
 				ADE8B26F50AFCAD208AC99F0 /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		2E53CB4A3AADFDD8E954FBA1 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				B0E708B64D2ED3CF952B4902 /* AppDestination.swift */,
+			);
+			path = Navigation;
 			sourceTree = "<group>";
 		};
 		2E63D37E9C6B73B603333623 /* ViewModels */ = {
@@ -1397,6 +1414,7 @@
 				5E8D38F19275D03369E77C3E /* NetworkInfoService.swift */,
 				4AF56381168C3FD77815FE7B /* NoOpSpeedTestService.swift */,
 				41299411CDDE99A5C409A044 /* RateAppService.swift */,
+				26335B5AC0E45923FD2B40C7 /* RSSIQuality+NSColor.swift */,
 				C8CC68CA1629217A3CE5A80F /* ShellCommandRunner.swift */,
 				6EE294C34E0DD9F4AB70452D /* ShellPingService.swift */,
 				96CAA6CB710E490DF3D17465 /* StatisticsService.swift */,
@@ -1422,6 +1440,7 @@
 			children = (
 				B0DAECD1C045E382C76FE56E /* App */,
 				77B302D7D2B731ADAF932526 /* AppIntents */,
+				2E53CB4A3AADFDD8E954FBA1 /* Navigation */,
 				12A4AC81526173A670D52622 /* Platform */,
 				CBB92A689511B91457179F45 /* Resources */,
 				10E4CCBCC6C445B127309731 /* ViewModels */,
@@ -1533,6 +1552,7 @@
 		B0DAECD1C045E382C76FE56E /* App */ = {
 			isa = PBXGroup;
 			children = (
+				8879D3BC07FD7C06C5AB3A37 /* AppEnvironment.swift */,
 				3EA4662449985A11EB4F4E7C /* DeepLinkRouter.swift */,
 				70325EC83FD1A8358DB60D64 /* NetmonitorApp.swift */,
 			);
@@ -2042,6 +2062,7 @@
 				D0CD37E8D9B698772C9ED7FA /* ProDeviceDetailView.swift in Sources */,
 				56BE0732C5AEF012678BEF86 /* ProModeRowView.swift in Sources */,
 				7C15E30650A9210433ED8208 /* QuickJumpSheet.swift in Sources */,
+				176CC089BB3E6B2AE3BDFA31 /* RSSIQuality+NSColor.swift in Sources */,
 				70926F040D08693ACF1B16B9 /* RateAppService.swift in Sources */,
 				7D9483D8831B8A58460A4154 /* SSLCertificateMonitorView.swift in Sources */,
 				0281A67F42E6230CC68B9CDF /* SchemaMigrationPlan.swift in Sources */,
@@ -2162,6 +2183,8 @@
 			files = (
 				DD662EDF2E1C33972E6BCC58 /* AcknowledgementsView.swift in Sources */,
 				A12A2FCB6ED9AAE4E43A361C /* AddNetworkSheet.swift in Sources */,
+				C56023FDB9FD3C9ADBD9BB18 /* AppDestination.swift in Sources */,
+				3D0555455D57DBBBE7619889 /* AppEnvironment.swift in Sources */,
 				E85684BBC2BAB6CF1B79E110 /* AppSettings.swift in Sources */,
 				F6A0097193D5AB17E285F940 /* AsyncTimeout.swift in Sources */,
 				DDB9CB792F522B464C563C42 /* BackgroundTaskService.swift in Sources */,
@@ -2218,6 +2241,7 @@
 				2B73ACAF4F9968979D32807D /* PortScannerToolView.swift in Sources */,
 				443BBA7B98165E5ADF205569 /* PortScannerToolViewModel.swift in Sources */,
 				39530BBB571E24F123543EC2 /* PublicIPService.swift in Sources */,
+				ABDED888167044934B94AA33 /* RSSIQuality+UIColor.swift in Sources */,
 				C22CD2C4F138EBB88F30000B /* RateAppService.swift in Sources */,
 				F4574FC8446A592B70216304 /* RoomPlanGeometryAdapter.swift in Sources */,
 				A28955B327782AFDC8BEE99F /* RoomPlanScanViewController.swift in Sources */,
@@ -2474,7 +2498,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.netmonitor.NetMonitor;
 				SDKROOT = macosx;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2552,7 +2575,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.netmonitor.NetMonitor;
 				SDKROOT = macosx;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2737,14 +2759,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 32XZRDTGK3;
 				INFOPLIST_FILE = "NetMonitor-iOS/Resources/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "NetMonitor Mobile";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor;
 				SDKROOT = iphoneos;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2762,14 +2781,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 32XZRDTGK3;
 				INFOPLIST_FILE = "NetMonitor-iOS/Resources/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "NetMonitor Mobile";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor;
 				SDKROOT = iphoneos;
 				SWIFT_STRICT_CONCURRENCY = complete;

--- a/NetMonitor-iOS/Resources/Info.plist
+++ b/NetMonitor-iOS/Resources/Info.plist
@@ -65,7 +65,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1776881717</string>
+	<string>4</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>shortcuts</string>

--- a/NetMonitor-iOS/ViewModels/SettingsViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/SettingsViewModel.swift
@@ -190,7 +190,7 @@ final class SettingsViewModel {
         isClearingCache = false
     }
 
-    private static func clearDirectory(at url: URL) {
+    private nonisolated static func clearDirectory(at url: URL) {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil) else { return }
         for file in contents {
@@ -208,7 +208,7 @@ final class SettingsViewModel {
         return total
     }
 
-    private static func directorySize(at url: URL) -> Int64 {
+    private nonisolated static func directorySize(at url: URL) -> Int64 {
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
         var total: Int64 = 0

--- a/NetMonitor-macOS/Resources/Info.plist
+++ b/NetMonitor-macOS/Resources/Info.plist
@@ -46,7 +46,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>1776881717</string>
+	<string>30</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/project.yml
+++ b/project.yml
@@ -31,7 +31,7 @@ targets:
       properties:
         CFBundleName: NetMonitor Pro
         CFBundleDisplayName: NetMonitor Pro
-        CFBundleShortVersionString: "2.2.0"
+        CFBundleShortVersionString: "2.2.1"
         CFBundleVersion: "30"
         LSMinimumSystemVersion: "15.0"
         NSPrincipalClass: NSApplication
@@ -147,8 +147,8 @@ targets:
       properties:
         CFBundleName: Netmonitor
         CFBundleDisplayName: Netmonitor
-        CFBundleShortVersionString: "2.2.0"
-        CFBundleVersion: "4"
+        CFBundleShortVersionString: "2.2.1"
+        CFBundleVersion: "9"
         CFBundleIconName: AppIcon
         NSCameraUsageDescription: "NetMonitor uses the camera for AR-assisted room scanning to create floor plans for Wi-Fi coverage surveys."
         NSLocationWhenInUseUsageDescription: "NetMonitor uses your location to display WiFi network information and monitor GeoFence zones."

--- a/project.yml
+++ b/project.yml
@@ -32,7 +32,7 @@ targets:
         CFBundleName: NetMonitor Pro
         CFBundleDisplayName: NetMonitor Pro
         CFBundleShortVersionString: "2.2.0"
-        CFBundleVersion: "29"
+        CFBundleVersion: "30"
         LSMinimumSystemVersion: "15.0"
         NSPrincipalClass: NSApplication
         NSHighResolutionCapable: true
@@ -148,7 +148,7 @@ targets:
         CFBundleName: Netmonitor
         CFBundleDisplayName: Netmonitor
         CFBundleShortVersionString: "2.2.0"
-        CFBundleVersion: "3"
+        CFBundleVersion: "4"
         CFBundleIconName: AppIcon
         NSCameraUsageDescription: "NetMonitor uses the camera for AR-assisted room scanning to create floor plans for Wi-Fi coverage surveys."
         NSLocationWhenInUseUsageDescription: "NetMonitor uses your location to display WiFi network information and monitor GeoFence zones."

--- a/project.yml
+++ b/project.yml
@@ -32,7 +32,7 @@ targets:
         CFBundleName: NetMonitor Pro
         CFBundleDisplayName: NetMonitor Pro
         CFBundleShortVersionString: "2.2.1"
-        CFBundleVersion: "30"
+        CFBundleVersion: "1776881719"
         LSMinimumSystemVersion: "15.0"
         NSPrincipalClass: NSApplication
         NSHighResolutionCapable: true


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
