### PR TITLE
Update AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,22 @@ gh issue close <number> --repo jbcrane13/NetMonitor-2.0 --comment "Done: <summar
 - 30fd109 perf(scan): cap probe fanout and stop ConnectionBudget overrun (#194, #195)
 - 4b26ad7 refactor: fix three DIP/LSP violations in ViewModels (#196)
 - 1e79ec1 feat(intents): return values + dialog from iOS App Intents (#199)
+
+## Activity — 2026-05-18
+- d0f30dc test(core): update NavigationSection expectations
+- 7a8eddf test(ios): avoid removed AppShortcut title accessor
+- 1b5f85d feat(ios): finish SwiftUI 6 recovery work
+- a9efc57 test(ios): cover speed test feedback triggers
+- ff6c8be Add PRD docs for issues 198, 212, 213
+- f50b37d test(core): expand ipv4ToUInt32 edge case coverage
+- 41e0b62 refactor(core): harden NetworkUtilities string decoding and route parsing
+- d725550 Add WorldPingService concurrency tests
+- c1e8202 fix(#213): gate SubnetCalculator sensoryFeedback on non-nil transitions
+- c5deecf feat: adopt SwiftUI 6 APIs (scrollTargetBehavior, sensoryFeedback, MeshGradient)
+- c06f865 feat(ios): adopt iOS 26 Liquid Glass APIs over .ultraThinMaterial (#212)
+- 6e5e0fe refactor(ios): inject AppEnvironment into remaining root views
+- 0e4292f Initial plan
+- db7a612 chore(deps): bump github.com/getsentry/sentry-cocoa
+- 4533871 refactor(heatmap): migrate macOS WiFiHeatmapViewModel onto HeatmapSurveyState (#202 heatmap, step 3)
+- 9cbb45b fix(lint): resolve swiftlint failures and remove stray claude worktrees
+- c3a076c Initial plan


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
