### PR TITLE
Chore/issue 221 named listener queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,3 +280,38 @@ gh issue close <number> --repo jbcrane13/NetMonitor-2.0 --comment "Done: <summar
 - 30fd109 perf(scan): cap probe fanout and stop ConnectionBudget overrun (#194, #195)
 - 4b26ad7 refactor: fix three DIP/LSP violations in ViewModels (#196)
 - 1e79ec1 feat(intents): return values + dialog from iOS App Intents (#199)
+
+## Activity — 2026-05-18
+- 85f5dbc Potential fix for pull request finding
+- 90b023b test(iOS): harden sensoryFeedback guard regression assertions
+- 53229c9 test(iOS): assert SubnetCalculator sensoryFeedback nil-guard clauses
+- 67e1ff8 Potential fix for pull request finding
+- c657b01 Potential fix for pull request finding
+- a13c8ef Potential fix for pull request finding
+- aeb86d8 Potential fix for pull request finding
+- 2504046 Potential fix for pull request finding
+- d0f30dc test(core): update NavigationSection expectations
+- 7a8eddf test(ios): avoid removed AppShortcut title accessor
+- 1b5f85d feat(ios): finish SwiftUI 6 recovery work
+- a9efc57 test(ios): cover speed test feedback triggers
+- ff6c8be Add PRD docs for issues 198, 212, 213
+- f50b37d test(core): expand ipv4ToUInt32 edge case coverage
+- 41e0b62 refactor(core): harden NetworkUtilities string decoding and route parsing
+- d725550 Add WorldPingService concurrency tests
+- c1e8202 fix(#213): gate SubnetCalculator sensoryFeedback on non-nil transitions
+- c5deecf feat: adopt SwiftUI 6 APIs (scrollTargetBehavior, sensoryFeedback, MeshGradient)
+- c06f865 feat(ios): adopt iOS 26 Liquid Glass APIs over .ultraThinMaterial (#212)
+- c158b00 Add PRD docs for issues 198, 212, 213
+- 19ab913 test(core): expand ipv4ToUInt32 edge case coverage
+- 5c25986 refactor(core): harden NetworkUtilities string decoding and route parsing
+- 5a3d089 fix(#213): gate SubnetCalculator sensoryFeedback on non-nil transitions
+- df02d50 feat(ios): adopt iOS 26 Liquid Glass APIs over .ultraThinMaterial (#212)
+- e2d0e60 Add WorldPingService concurrency tests
+- 39a5cbd feat: adopt SwiftUI 6 APIs (scrollTargetBehavior, sensoryFeedback, MeshGradient)
+- 6e5e0fe refactor(ios): inject AppEnvironment into remaining root views
+- 0e4292f Initial plan
+- c2d14bb Update .gitignore
+- db7a612 chore(deps): bump github.com/getsentry/sentry-cocoa
+- 4533871 refactor(heatmap): migrate macOS WiFiHeatmapViewModel onto HeatmapSurveyState (#202 heatmap, step 3)
+- 9cbb45b fix(lint): resolve swiftlint failures and remove stray claude worktrees
+- c3a076c Initial plan

--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -58,13 +58,16 @@
 		190838A3E12806448FE26392 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8650B3D9EC5CDB844E93B843 /* SettingsView.swift */; };
 		194EE73D3283999F3304585E /* DeviceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDA399D48F75F6B320DA095 /* DeviceDetailView.swift */; };
 		1991B7FB607C1B52DB0F10EF /* ToolsGoldenPathUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9B8228A5B2FFCD294C88EC /* ToolsGoldenPathUITests.swift */; };
+		19A31C753CF4B6DE148F6C41 /* LabelValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1FE76E2FDC78460F33EE00 /* LabelValueRow.swift */; };
 		1AC825964136B5A84054659E /* ISPCardErrorSurfacingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3970DE448DE2D230066F264D /* ISPCardErrorSurfacingTests.swift */; };
 		1B2336C58CC2514B16049786 /* MacOSInteractionFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D55E3AA39B425C3CEEC358 /* MacOSInteractionFlowUITests.swift */; };
 		1C819F0E94B6B3C33901A8B9 /* PostScanRefinementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884331E906096344FF4F5D46 /* PostScanRefinementTests.swift */; };
 		1D97DE9D80C8A558319C7674 /* WebBrowserToolUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9403AD0B1B08EAF0A4CEA /* WebBrowserToolUITests.swift */; };
+		1F9D709801579A90BF11B932 /* MonitoringActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695AA592F01C6645F07F312F /* MonitoringActivity.swift */; };
 		1FF674FCF442FBC2A78D53D2 /* GeoFenceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2179DEB3D5E16AC768DF095A /* GeoFenceManagerTests.swift */; };
 		206584B8ACCF8ED6A773C4FE /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C146A39287FFF5DD38F8C3 /* TestHelpers.swift */; };
 		207575742BF4C0440A782BD6 /* SubnetCalculatorToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FEF8C98AA01BED84B73181 /* SubnetCalculatorToolView.swift */; };
+		20D60EAD6B79561CB1E8CE97 /* AGENTS.md in Resources */ = {isa = PBXBuildFile; fileRef = 0FCE51303E1119E639A5B8C2 /* AGENTS.md */; };
 		21029659A5E393FF4BE5174A /* WHOISToolViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C16AD1D5A29DB71D72A39D4 /* WHOISToolViewModelTests.swift */; };
 		2154DEEBE29F72B0962B2599 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273DFEA060BE77C6F58BE72B /* AppIntentsTests.swift */; };
 		2330438B644B8CF9BB92653B /* ShellPingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE294C34E0DD9F4AB70452D /* ShellPingService.swift */; };
@@ -75,6 +78,7 @@
 		25860CEF3284B9B3375ED175 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415295A040809C20DB62832 /* MenuBarController.swift */; };
 		2614A26247D6F24EFC0826FE /* SpeedTestToolUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6321E1A30E4AEF89B9C9F4BE /* SpeedTestToolUITests.swift */; };
 		26305CE06BC04D36606602D9 /* WiFiInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE1A85A0AC80D9B08D16B53 /* WiFiInfoService.swift */; };
+		2672EF3F5D8C1C08FC039F0B /* NetMonitorWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9A36F703FFCFB6AD4FBB0CBD /* NetMonitorWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		26D987DF605D304854BB2D3A /* ContinuationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088D4FC2A90AF0ADBFF9955B /* ContinuationTracker.swift */; };
 		29799117EC4104E4510D2AF8 /* ToolInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28840E366E12B65E3AAD7F2E /* ToolInputField.swift */; };
 		2A579C8C2E53E2AB1C943507 /* WiFiInfoServiceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6861528C7B73A27CA7BEDCC /* WiFiInfoServiceCacheTests.swift */; };
@@ -142,6 +146,7 @@
 		4CBC785A140CF616B7C1EAF6 /* BlueprintRoundTripContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D069092C7D3C2D477739790 /* BlueprintRoundTripContractTests.swift */; };
 		4CC96EA143CB7A03C58AD8FF /* DeviceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1FBBC1DD3CF85853D633F6 /* DeviceDetailView.swift */; };
 		4E634E7C711C966E0522C80F /* PublicIPServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC30204FAADF62E903865979 /* PublicIPServiceTests.swift */; };
+		4E72AFBFDD244A2C0A433ECD /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE1D8C5F900E64248573737 /* AppSettings.swift */; };
 		4F0B754BE3498779A22DDB1A /* WebBrowserToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B68963D40A139DE9EF2272 /* WebBrowserToolView.swift */; };
 		4F957102AF0E1F220EE11861 /* SettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674DF2A6E73DEA21A751E2A6 /* SettingsUITests.swift */; };
 		516EF4009098D3018F255138 /* EnumExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E552E75FCB9CC89B03283A8 /* EnumExtensions.swift */; };
@@ -256,6 +261,8 @@
 		8B9BC2466AACD7E261F5E8CC /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33FA8CEF889C0CD95DE23EF /* GlassButton.swift */; };
 		8BAD0EA03B94A03D137BD591 /* ToolsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F317095264FEEBC1533465 /* ToolsViewUITests.swift */; };
 		8CEE50A29FC6943DE98EABC3 /* WakeOnLanToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B2842ECC13155C42B01207 /* WakeOnLanToolView.swift */; };
+		8DBE3DAB03B618D4130CA021 /* NetmonitorWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865788432068C52D3C922C90 /* NetmonitorWidget.swift */; };
+		8DCAE89B23C4BFE39C9CDCF8 /* NetworkScanActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2746D96C15673D48AAA752C2 /* NetworkScanActivity.swift */; };
 		8DEBD7188452657834F7EFFF /* BandwidthMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED714BFBF69259A62EF490EA /* BandwidthMonitorServiceTests.swift */; };
 		8E49595DB6E4ED2E0C4DDEF1 /* HTTPMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9397061B694F2821A01D1805 /* HTTPMonitorService.swift */; };
 		8F7A9368E876A861DAE933F1 /* DeviceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D31E0912E4D4C961789D8F /* DeviceListView.swift */; };
@@ -314,10 +321,12 @@
 		B115BF5D739E30DCE0B42104 /* CompanionSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8545002C8292919E27080D /* CompanionSettingsView.swift */; };
 		B161CB7F597C703711BDDE56 /* DNSLookupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A064CE98C7F5FDE16358B4 /* DNSLookupServiceTests.swift */; };
 		B215F1978E6F4EF994AB9B13 /* DefaultTargetsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18594F466B7F7B0935132FD2 /* DefaultTargetsProviderTests.swift */; };
+		B2D2BB69FA459FA0D19CAF42 /* LiveActivityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D78D7597A47DA8E3CB14A7 /* LiveActivityViews.swift */; };
 		B35A964B779E100AE621D5CA /* ToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1AB5AF130A23C56CBDDD00 /* ToolsView.swift */; };
 		B36B2F6CB68D44649515AA06 /* VPNInfoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BDC838230764B6AA69A835 /* VPNInfoUITests.swift */; };
 		B59FE87FA927961BCB358956 /* GeoFenceSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F942F3EB24C228A07F303EA /* GeoFenceSettingsUITests.swift */; };
 		B5C58E5DC1825BD6609D274B /* MiniSparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA84BE258FB44E79A514C66 /* MiniSparklineView.swift */; };
+		B76E63A805AD6382FF712F08 /* NetMonitorCore in Frameworks */ = {isa = PBXBuildFile; productRef = D31F8242EE281886CCDE5A5D /* NetMonitorCore */; };
 		B8D8F09CE7D6FD7997C0BDEB /* MacNetworkMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5C5F9EF530BB6FA79E1972 /* MacNetworkMonitorTests.swift */; };
 		B900445CE1D393D733289207 /* NetworkEventServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE584A8394FFA0BFC9255154 /* NetworkEventServiceTests.swift */; };
 		B90A3DA2C8AC570A246AC885 /* PortScannerToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5895DED1FC083716813EB576 /* PortScannerToolView.swift */; };
@@ -328,6 +337,7 @@
 		BD68EC4595B15C5E803247FB /* HealthGaugeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02DB6EA4594C1AC7060BBB0 /* HealthGaugeCard.swift */; };
 		BE461DAF57D86AE376B42C29 /* ShellPingParserExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083DFBA71337005E43B2F619 /* ShellPingParserExtendedTests.swift */; };
 		BFE249ACB3E6B37627E1E493 /* ConnectivityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B492B6D206C4A83BE984640B /* ConnectivityMonitorTests.swift */; };
+		C1FE2E51EF14F1CF5DDB86A8 /* LabelValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4242598E5085508175C23443 /* LabelValueRow.swift */; };
 		C22CD2C4F138EBB88F30000B /* RateAppService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08548A1C1E2724BA55054DBB /* RateAppService.swift */; };
 		C27D1C5E68E88D4354AA53DC /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3D104B92118BB96E87C4E1 /* OnboardingView.swift */; };
 		C323E9367B0F864A8517172D /* ISPLookupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0203A45AF57DA6D9B5EDF5F5 /* ISPLookupServiceTests.swift */; };
@@ -345,6 +355,7 @@
 		C79AA5C890E1B26523168091 /* TracerouteToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36F41C60900EB945E888E23 /* TracerouteToolView.swift */; };
 		C872123DA12DFED11C7A6161 /* UITestBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE29B6619C0856A7E827AA2 /* UITestBootstrap.swift */; };
 		C8A1D1542966EAD744A3905F /* PDFReportGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A6E7FD29C99FBEC41B588C /* PDFReportGeneratorTests.swift */; };
+		C8CFC0FE69D1956EB2FD5522 /* SpeedTestActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3A75D6ACCC208F5EE2B7B2 /* SpeedTestActivity.swift */; };
 		C92EAFAD12E0D1149774F488 /* BackgroundTaskServiceExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBB18011D6E61DA946962CD /* BackgroundTaskServiceExtendedTests.swift */; };
 		C93350DC36F292072A92CAB8 /* RoomPlanTaskTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3E1EF9892EF0E721B4E8F7 /* RoomPlanTaskTimeout.swift */; };
 		C9B3B7AE7F396A3E054A0303 /* ISPLookupServiceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7CEC4120984D8B5722E5 /* ISPLookupServiceContractTests.swift */; };
@@ -470,6 +481,13 @@
 			remoteGlobalIDString = 1F7C65C74B339FCF977C4759;
 			remoteInfo = "NetMonitor-macOS";
 		};
+		CEBA63D1A7091EC3EDD7EAAD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4FB80C4151AD239413B6733F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 46136558EDB186C25492B378;
+			remoteInfo = NetMonitorWidgetExtension;
+		};
 		E282969DAF3D18AFA509F001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4FB80C4151AD239413B6733F /* Project object */;
@@ -478,6 +496,20 @@
 			remoteInfo = "NetMonitor-iOS";
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		2F915B7CA72F8B6CE54E0417 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				2672EF3F5D8C1C08FC039F0B /* NetMonitorWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		00129DE4AC923EE5FBB09BFE /* WorldPingToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingToolUITests.swift; sourceTree = "<group>"; };
@@ -510,6 +542,7 @@
 		0D6A9E0C9DE615916C7BBA89 /* PlatformServiceGapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformServiceGapTests.swift; sourceTree = "<group>"; };
 		0E678FCAC5AC181A1C62585D /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		0F14EF1F24FAD8E279C5F619 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		0FCE51303E1119E639A5B8C2 /* AGENTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AGENTS.md; sourceTree = "<group>"; };
 		101EF594B6858D3F18BCD641 /* DashboardUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUITests.swift; sourceTree = "<group>"; };
 		101F26E4BECFFBFB3797E920 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		113F54C8B77279EBFE7FBF0D /* IOSUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSUITestCase.swift; sourceTree = "<group>"; };
@@ -552,6 +585,7 @@
 		247C2718CDBD3187540F4A47 /* SpeedTestIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestIntent.swift; sourceTree = "<group>"; };
 		26335B5AC0E45923FD2B40C7 /* RSSIQuality+NSColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSSIQuality+NSColor.swift"; sourceTree = "<group>"; };
 		273DFEA060BE77C6F58BE72B /* AppIntentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
+		2746D96C15673D48AAA752C2 /* NetworkScanActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkScanActivity.swift; sourceTree = "<group>"; };
 		28840E366E12B65E3AAD7F2E /* ToolInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolInputField.swift; sourceTree = "<group>"; };
 		2926D7C25A7E15A889609FFE /* FunctionalSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalSmokeTests.swift; sourceTree = "<group>"; };
 		294BE57FBA3FFA271BE7B9B5 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
@@ -601,6 +635,7 @@
 		41299411CDDE99A5C409A044 /* RateAppService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateAppService.swift; sourceTree = "<group>"; };
 		417305C569EB2774490CA2BB /* WakeOnLANToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakeOnLANToolViewModel.swift; sourceTree = "<group>"; };
 		41CF7CEC4120984D8B5722E5 /* ISPLookupServiceContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceContractTests.swift; sourceTree = "<group>"; };
+		4242598E5085508175C23443 /* LabelValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelValueRow.swift; sourceTree = "<group>"; };
 		431FA615915AAEDF20F196DC /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		438C3AA19D5D1840BB273D64 /* WorldPingToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingToolView.swift; sourceTree = "<group>"; };
 		44AADB70157B20E77264BBC0 /* MacThemeContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacThemeContrastTests.swift; sourceTree = "<group>"; };
@@ -653,12 +688,14 @@
 		60E5A31E2CCBA2EAB2AA0E09 /* TargetsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetsUITests.swift; sourceTree = "<group>"; };
 		6265B72D55BCAD7A4DF3AA20 /* GeoTraceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoTraceView.swift; sourceTree = "<group>"; };
 		6321E1A30E4AEF89B9C9F4BE /* SpeedTestToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestToolUITests.swift; sourceTree = "<group>"; };
+		63D78D7597A47DA8E3CB14A7 /* LiveActivityViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityViews.swift; sourceTree = "<group>"; };
 		65DD482FB958FC0A76B656CE /* PingToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingToolViewModel.swift; sourceTree = "<group>"; };
 		66EEF66329B8A2875D465BDB /* WiFiHeatmapViewModelExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiHeatmapViewModelExportTests.swift; sourceTree = "<group>"; };
 		66FCAD51E87A57B8106A76CD /* HeatmapFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapFileManager.swift; sourceTree = "<group>"; };
 		673FFB780C1777738E437731 /* RoomPlanScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPlanScannerViewModel.swift; sourceTree = "<group>"; };
 		674DF2A6E73DEA21A751E2A6 /* SettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITests.swift; sourceTree = "<group>"; };
 		6791657706821C08F331AB13 /* HeatmapSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapSurveyViewModel.swift; sourceTree = "<group>"; };
+		695AA592F01C6645F07F312F /* MonitoringActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitoringActivity.swift; sourceTree = "<group>"; };
 		697FD6AA545E38F7DFD1F806 /* HeatmapExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapExporter.swift; sourceTree = "<group>"; };
 		6A3C5A26C422CE3455CD55A3 /* TimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineView.swift; sourceTree = "<group>"; };
 		6AC7F633EA592CA1A5D2F95C /* CompanionMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionMessageHandlerTests.swift; sourceTree = "<group>"; };
@@ -709,6 +746,7 @@
 		83FE883399BD31C021DC7BEF /* PortScannerToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerToolViewModel.swift; sourceTree = "<group>"; };
 		85EADE9676FF124E9D257FBC /* MonitoringSessionSaveErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitoringSessionSaveErrorTests.swift; sourceTree = "<group>"; };
 		8650B3D9EC5CDB844E93B843 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		865788432068C52D3C922C90 /* NetmonitorWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetmonitorWidget.swift; sourceTree = "<group>"; };
 		86ED939D42AAE689A270FBC7 /* ShortcutsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsUITests.swift; sourceTree = "<group>"; };
 		87872515F353D25925C60B81 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		87C68BBDE6DB8F7C4E446FEE /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
@@ -744,6 +782,7 @@
 		9918AEA9A38CB534D5DCB15B /* NetworkMapUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMapUITests.swift; sourceTree = "<group>"; };
 		99435F2A9092DB49F47FBBAB /* MenuBarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarUITests.swift; sourceTree = "<group>"; };
 		9A1AB5AF130A23C56CBDDD00 /* ToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsView.swift; sourceTree = "<group>"; };
+		9A36F703FFCFB6AD4FBB0CBD /* NetMonitorWidgetExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = NetMonitorWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A465B41D381F8398CA152ED /* StatisticsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsServiceTests.swift; sourceTree = "<group>"; };
 		9A79D4FB9897BC63CA4E8796 /* GeoFenceManagerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoFenceManagerErrorTests.swift; sourceTree = "<group>"; };
 		9AAC604B1E0F72FE3F484FF1 /* NetworkHealthScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHealthScoreView.swift; sourceTree = "<group>"; };
@@ -796,6 +835,7 @@
 		B95AD20B5D8E360138D27BC7 /* NewFeatureUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureUnitTests.swift; sourceTree = "<group>"; };
 		BA99B879D32BE1A79C557AA6 /* AppearanceModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceModeTests.swift; sourceTree = "<group>"; };
 		BAC76B1286C767294ED03042 /* ISPCardViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPCardViewModelExtendedTests.swift; sourceTree = "<group>"; };
+		BC3A75D6ACCC208F5EE2B7B2 /* SpeedTestActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTestActivity.swift; sourceTree = "<group>"; };
 		BC50DF5BC553FC2B2E1E51FA /* ISPLookupServiceCacheErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceCacheErrorTests.swift; sourceTree = "<group>"; };
 		BC9B8228A5B2FFCD294C88EC /* ToolsGoldenPathUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsGoldenPathUITests.swift; sourceTree = "<group>"; };
 		BCD97CE135CA42D41D9F1A8F /* WorldPingToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingToolView.swift; sourceTree = "<group>"; };
@@ -855,6 +895,7 @@
 		D8D1C5A8A2026164E837DC8B /* NetMonitor-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NetMonitor-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5FD1B08685EFEC9DBB7A93 /* VPNInfoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNInfoViewModelTests.swift; sourceTree = "<group>"; };
 		DAAB8EFA459C03B0EA468DF9 /* DeviceDiscoveryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDiscoveryServiceTests.swift; sourceTree = "<group>"; };
+		DAD637AD0609DA09F9CE0C8A /* NetMonitorWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetMonitorWidgetExtension.entitlements; sourceTree = "<group>"; };
 		DBB29135703E0FE0FA145BEA /* SharedViewModelHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedViewModelHelpers.swift; sourceTree = "<group>"; };
 		DC30204FAADF62E903865979 /* PublicIPServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicIPServiceTests.swift; sourceTree = "<group>"; };
 		DC305967909AD6181CCCF48C /* SettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITests.swift; sourceTree = "<group>"; };
@@ -878,6 +919,7 @@
 		E6A543B7D3C0991842ACBCF5 /* DNSLookupToolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSLookupToolUITests.swift; sourceTree = "<group>"; };
 		E6EF38CEF0231AAE6BBD44A3 /* EdgeCasesAndErrorStatesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCasesAndErrorStatesUITests.swift; sourceTree = "<group>"; };
 		E719E41F16DE685161031931 /* ShortcutsWiFiProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsWiFiProvider.swift; sourceTree = "<group>"; };
+		E8450289FB75CAD2C7932359 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E87FC6613ED347223FA691D0 /* TCPMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCPMonitorService.swift; sourceTree = "<group>"; };
 		E887E0CE88F2010495521830 /* WHOISToolViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHOISToolViewModelExtendedTests.swift; sourceTree = "<group>"; };
 		E8EF1F6838D25BB110551ABB /* BonjourDiscoveryToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourDiscoveryToolView.swift; sourceTree = "<group>"; };
@@ -914,6 +956,7 @@
 		F84B2379791919EAF70CBFB5 /* MacOSToolOutcomeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSToolOutcomeUITests.swift; sourceTree = "<group>"; };
 		F9745FD9482D4F193CBA93FE /* TracerouteToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerouteToolViewModel.swift; sourceTree = "<group>"; };
 		F9BEAD2E8115A4C29314AF76 /* TargetManagerExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetManagerExtendedTests.swift; sourceTree = "<group>"; };
+		FA1FE76E2FDC78460F33EE00 /* LabelValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelValueRow.swift; sourceTree = "<group>"; };
 		FA3B15479F5CBB23DFFDC05E /* MacPairingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPairingUITests.swift; sourceTree = "<group>"; };
 		FB80047F0EAF4F9DE0C0E360 /* WorldPingServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		FC804A214B32FE44709510C9 /* DeviceDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDetailViewModelTests.swift; sourceTree = "<group>"; };
@@ -930,6 +973,14 @@
 			files = (
 				30EBD9CDD0FE403E1E756338 /* NetMonitorCore in Frameworks */,
 				ACC9E2AAC225ACE46FFA7690 /* NetworkScanKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		260732E263DA431A4ADBBC9B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B76E63A805AD6382FF712F08 /* NetMonitorCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -994,6 +1045,18 @@
 				CC3A58AF8659A7CFB38E1E2D /* MockURLProtocol.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		0D32924BA35DB2FCB5CC0DEB /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				0FCE51303E1119E639A5B8C2 /* AGENTS.md */,
+				E8450289FB75CAD2C7932359 /* Info.plist */,
+				865788432068C52D3C922C90 /* NetmonitorWidget.swift */,
+				DAD637AD0609DA09F9CE0C8A /* NetMonitorWidgetExtension.entitlements */,
+				732FE41DB501DBC6BA559766 /* LiveActivity */,
+			);
+			path = Widget;
 			sourceTree = "<group>";
 		};
 		0D4D0765E3E667C3E2CDAD0C /* Views */ = {
@@ -1129,6 +1192,7 @@
 				D8D1C5A8A2026164E837DC8B /* NetMonitor-macOS.app */,
 				1BFA32A2D8AD16EEFF35C181 /* NetMonitor-macOSTests.xctest */,
 				80FE23B27BDE116B2FF20485 /* NetMonitor-macOSUITests.xctest */,
+				9A36F703FFCFB6AD4FBB0CBD /* NetMonitorWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1157,6 +1221,7 @@
 				E0F5FE876022BF83E2244721 /* AddNetworkSheet.swift */,
 				2318C9AFCEE31C60D3E14516 /* EmptyStateView.swift */,
 				D33FA8CEF889C0CD95DE23EF /* GlassButton.swift */,
+				4242598E5085508175C23443 /* LabelValueRow.swift */,
 				2C3943143B99D5243073376A /* MetricCard.swift */,
 				EE0A10C8D0A4922F6690C62B /* StatusBadge.swift */,
 				6EBC131061CB2EF8420343A0 /* ToolClearButton.swift */,
@@ -1261,6 +1326,17 @@
 				294BE57FBA3FFA271BE7B9B5 /* MockURLProtocol.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		732FE41DB501DBC6BA559766 /* LiveActivity */ = {
+			isa = PBXGroup;
+			children = (
+				63D78D7597A47DA8E3CB14A7 /* LiveActivityViews.swift */,
+				695AA592F01C6645F07F312F /* MonitoringActivity.swift */,
+				2746D96C15673D48AAA752C2 /* NetworkScanActivity.swift */,
+				BC3A75D6ACCC208F5EE2B7B2 /* SpeedTestActivity.swift */,
+			);
+			path = LiveActivity;
 			sourceTree = "<group>";
 		};
 		77B302D7D2B731ADAF932526 /* AppIntents */ = {
@@ -1454,6 +1530,7 @@
 				CBB92A689511B91457179F45 /* Resources */,
 				10E4CCBCC6C445B127309731 /* ViewModels */,
 				0D4D0765E3E667C3E2CDAD0C /* Views */,
+				0D32924BA35DB2FCB5CC0DEB /* Widget */,
 			);
 			path = "NetMonitor-iOS";
 			sourceTree = "<group>";
@@ -1747,6 +1824,7 @@
 			children = (
 				A5380F904D8A46DD9A585ACA /* CardStateViews.swift */,
 				8F7663D6B71E58A8F1302100 /* FlowLayout.swift */,
+				FA1FE76E2FDC78460F33EE00 /* LabelValueRow.swift */,
 				5EA84BE258FB44E79A514C66 /* MiniSparklineView.swift */,
 				30C5FE8DF81C4531CE1DFD8C /* QuickJumpSheet.swift */,
 			);
@@ -1777,6 +1855,26 @@
 			productName = "NetMonitor-macOS";
 			productReference = D8D1C5A8A2026164E837DC8B /* NetMonitor-macOS.app */;
 			productType = "com.apple.product-type.application";
+		};
+		46136558EDB186C25492B378 /* NetMonitorWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 01FE6C30472033C8ACC4B6A7 /* Build configuration list for PBXNativeTarget "NetMonitorWidgetExtension" */;
+			buildPhases = (
+				D5E23DB787BCEDF84CAB2F8D /* Sources */,
+				2AC4DF81B4B7C3AA09AFDD73 /* Resources */,
+				260732E263DA431A4ADBBC9B /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NetMonitorWidgetExtension;
+			packageProductDependencies = (
+				D31F8242EE281886CCDE5A5D /* NetMonitorCore */,
+			);
+			productName = NetMonitorWidgetExtension;
+			productReference = 9A36F703FFCFB6AD4FBB0CBD /* NetMonitorWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		55DBFE8BA4B4B55A24D71850 /* NetMonitor-macOSTests */ = {
 			isa = PBXNativeTarget;
@@ -1839,11 +1937,13 @@
 				51F41E664F89550B3C7052B8 /* Sources */,
 				2BCAAFEC35BF88FCB2A74750 /* Resources */,
 				72EFE52898663F0A61ABF857 /* Frameworks */,
+				2F915B7CA72F8B6CE54E0417 /* Embed Foundation Extensions */,
 				20B78B45565446A31816D6B3 /* SwiftLint */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				E6296F9E4D174FE9E8575520 /* PBXTargetDependency */,
 			);
 			name = "NetMonitor-iOS";
 			packageProductDependencies = (
@@ -1885,6 +1985,10 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					1F7C65C74B339FCF977C4759 = {
+						DevelopmentTeam = 32XZRDTGK3;
+						ProvisioningStyle = Automatic;
+					};
+					46136558EDB186C25492B378 = {
 						DevelopmentTeam = 32XZRDTGK3;
 						ProvisioningStyle = Automatic;
 					};
@@ -1932,11 +2036,20 @@
 				1F7C65C74B339FCF977C4759 /* NetMonitor-macOS */,
 				55DBFE8BA4B4B55A24D71850 /* NetMonitor-macOSTests */,
 				A433A8E38101EED718D3EF55 /* NetMonitor-macOSUITests */,
+				46136558EDB186C25492B378 /* NetMonitorWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2AC4DF81B4B7C3AA09AFDD73 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				20D60EAD6B79561CB1E8CE97 /* AGENTS.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2BCAAFEC35BF88FCB2A74750 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2044,6 +2157,7 @@
 				7AEA2BCE64EF585A1AB3CB8E /* ISPInfoCard.swift in Sources */,
 				BCFFD1BAF88C94F8A8316F0A /* ISPLookupService.swift in Sources */,
 				E826C770B38906452AB06FE5 /* InternetActivityCard.swift in Sources */,
+				19A31C753CF4B6DE148F6C41 /* LabelValueRow.swift in Sources */,
 				33B22A41B19AD0D5DE178269 /* LatencyAnalysisCard.swift in Sources */,
 				FE417B8E8E6E543BFE4E7FEB /* LocalDeviceQueries.swift in Sources */,
 				AAF35FC2E47B9088503B00FF /* Logging.swift in Sources */,
@@ -2232,6 +2346,7 @@
 				CEFD08671D1E06FEBD714AD1 /* HeatmapSurveyView.swift in Sources */,
 				9B7E31EEE3622C87037B6E54 /* HeatmapSurveyViewModel.swift in Sources */,
 				F0A67D40676BC3A7277D1A88 /* IOSHeatmapService.swift in Sources */,
+				C1FE2E51EF14F1CF5DDB86A8 /* LabelValueRow.swift in Sources */,
 				67275F43A6AD4590D44AB5E9 /* LiquidGlass.swift in Sources */,
 				A03E60BC948179BA0D8716AC /* LiveActivityManager.swift in Sources */,
 				7BA2EFAB046BA9070DA4A42E /* Logging.swift in Sources */,
@@ -2470,6 +2585,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D5E23DB787BCEDF84CAB2F8D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E72AFBFDD244A2C0A433ECD /* AppSettings.swift in Sources */,
+				B2D2BB69FA459FA0D19CAF42 /* LiveActivityViews.swift in Sources */,
+				1F9D709801579A90BF11B932 /* MonitoringActivity.swift in Sources */,
+				8DBE3DAB03B618D4130CA021 /* NetmonitorWidget.swift in Sources */,
+				8DCAE89B23C4BFE39C9CDCF8 /* NetworkScanActivity.swift in Sources */,
+				C8CFC0FE69D1956EB2FD5522 /* SpeedTestActivity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2492,6 +2620,11 @@
 			isa = PBXTargetDependency;
 			target = 1F7C65C74B339FCF977C4759 /* NetMonitor-macOS */;
 			targetProxy = 74A0D377237A67323D05206B /* PBXContainerItemProxy */;
+		};
+		E6296F9E4D174FE9E8575520 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 46136558EDB186C25492B378 /* NetMonitorWidgetExtension */;
+			targetProxy = CEBA63D1A7091EC3EDD7EAAD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2570,6 +2703,27 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2F0E10C2794656FA3F0177FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 32XZRDTGK3;
+				INFOPLIST_FILE = "NetMonitor-iOS/Widget/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor.widget;
+				SDKROOT = iphoneos;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2784,6 +2938,27 @@
 			};
 			name = Release;
 		};
+		C5FE8EFB0DC91B71E1818AE2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 32XZRDTGK3;
+				INFOPLIST_FILE = "NetMonitor-iOS/Widget/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.blakemiller.netmonitor.widget;
+				SDKROOT = iphoneos;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		C87E3540A98DC61B077D458F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2872,6 +3047,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		01FE6C30472033C8ACC4B6A7 /* Build configuration list for PBXNativeTarget "NetMonitorWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C5FE8EFB0DC91B71E1818AE2 /* Debug */,
+				2F0E10C2794656FA3F0177FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		21FF443B62CD5C892E54B0AC /* Build configuration list for PBXProject "NetMonitor-2.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2972,6 +3156,10 @@
 		C0F47FE6FA4E6294CF46C936 /* NetworkScanKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkScanKit;
+		};
+		D31F8242EE281886CCDE5A5D /* NetMonitorCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NetMonitorCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/NetMonitor-iOS/Platform/AppIntents/NetMonitorShortcuts.swift
+++ b/NetMonitor-iOS/Platform/AppIntents/NetMonitorShortcuts.swift
@@ -2,6 +2,16 @@ import AppIntents
 
 /// Registers suggested Siri phrases and Shortcuts for NetMonitor's key actions.
 struct NetMonitorShortcuts: AppShortcutsProvider {
+    enum ShortcutID: CaseIterable {
+        case ping
+        case scanNetwork
+        case speedTest
+        case networkStatus
+        case saveWiFiReading
+    }
+
+    static let shortcutIDs: [ShortcutID] = ShortcutID.allCases
+
     @AppShortcutsBuilder
     static var appShortcuts: [AppShortcut] {
         AppShortcut(

--- a/NetMonitor-iOS/Resources/Info.plist
+++ b/NetMonitor-iOS/Resources/Info.plist
@@ -52,7 +52,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -65,7 +65,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>10</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>shortcuts</string>

--- a/NetMonitor-iOS/ViewModels/BonjourDiscoveryToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/BonjourDiscoveryToolViewModel.swift
@@ -20,10 +20,15 @@ final class BonjourDiscoveryToolViewModel {
     // MARK: - Dependencies
 
     private let bonjourService: any BonjourDiscoveryServiceProtocol
+    private let activityLog: ToolActivityLog
     private var pollingTask: Task<Void, Never>?
 
-    init(bonjourService: any BonjourDiscoveryServiceProtocol = BonjourDiscoveryService()) {
+    init(
+        bonjourService: any BonjourDiscoveryServiceProtocol = BonjourDiscoveryService(),
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.bonjourService = bonjourService
+        self.activityLog = activityLog
     }
 
     // MARK: - Computed Properties
@@ -77,7 +82,7 @@ final class BonjourDiscoveryToolViewModel {
             guard let self, !Task.isCancelled else { return }
             self.bonjourService.stopDiscovery()
             self.isDiscovering = false
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "Bonjour",
                 target: "Local Network",
                 result: "\(self.services.count) services",

--- a/NetMonitor-iOS/ViewModels/DNSLookupToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/DNSLookupToolViewModel.swift
@@ -27,9 +27,15 @@ final class DNSLookupToolViewModel {
     // MARK: - Dependencies
 
     private let dnsService: any DNSLookupServiceProtocol
+    private let activityLog: ToolActivityLog
 
-    init(dnsService: any DNSLookupServiceProtocol = DNSLookupService(), initialDomain: String? = nil) {
+    init(
+        dnsService: any DNSLookupServiceProtocol = DNSLookupService(),
+        initialDomain: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.dnsService = dnsService
+        self.activityLog = activityLog
         if let initialDomain = initialDomain {
             self.domain = initialDomain
         }
@@ -68,7 +74,7 @@ final class DNSLookupToolViewModel {
 
         let trimmedDomain = domain.trimmingCharacters(in: .whitespaces)
         if let result {
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "DNS Lookup",
                 target: trimmedDomain,
                 result: "\(result.records.count) records",
@@ -76,7 +82,7 @@ final class DNSLookupToolViewModel {
             )
         } else {
             errorMessage = dnsService.lastError ?? "Lookup failed"
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "DNS Lookup",
                 target: trimmedDomain,
                 result: "Failed",

--- a/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
@@ -269,20 +269,31 @@ final class DashboardViewModel {
     }
 
     /// Ping well-known anchors to show real external latency.
+    /// Pings run concurrently via `withTaskGroup` so worst-case latency is bounded by
+    /// the slowest single anchor instead of the sum across all anchors.
     private func measureAnchors() async {
         let anchors = ["Google": "8.8.8.8", "Cloudflare": "1.1.1.1", "Apple": "17.253.144.10"]
-        for (name, host) in anchors {
-            let stream = await pingService.ping(host: host, count: 1, timeout: 2)
-            var measured = false
-            for await result in stream {
-                if !result.isTimeout {
-                    anchorLatencies[name] = result.time
-                    measured = true
+
+        let results = await withTaskGroup(of: (String, Double?).self) { [pingService] group in
+            for (name, host) in anchors {
+                group.addTask {
+                    let stream = await pingService.ping(host: host, count: 1, timeout: 2)
+                    var latency: Double?
+                    for await result in stream where !result.isTimeout {
+                        latency = result.time
+                    }
+                    return (name, latency)
                 }
             }
-            if !measured {
-                anchorLatencies[name] = nil
+            var collected: [(String, Double?)] = []
+            for await result in group {
+                collected.append(result)
             }
+            return collected
+        }
+
+        for (name, latency) in results {
+            anchorLatencies[name] = latency
         }
 
         // Log a summary event for anchors

--- a/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
@@ -12,6 +12,7 @@ final class DashboardViewModel {
     private var autoRefreshTask: Task<Void, Never>?
     private let networkProfileManager: NetworkProfileManager
     private let pingService: any PingServiceProtocol
+    private let activityLog: ToolActivityLog
     private let userDefaults: UserDefaults
     private var lastLoggedGatewayLatency: Double?
     private var lastLoggedWiFiSSID: String?
@@ -52,6 +53,7 @@ final class DashboardViewModel {
         macConnectionService: any MacConnectionServiceProtocol = MacConnectionService.shared,
         networkProfileManager: NetworkProfileManager = NetworkProfileManager(),
         pingService: any PingServiceProtocol = PingService(),
+        activityLog: ToolActivityLog = .shared,
         userDefaults: UserDefaults = .standard
     ) {
         self.networkMonitor = networkMonitor
@@ -62,6 +64,7 @@ final class DashboardViewModel {
         self.macConnectionService = macConnectionService
         self.networkProfileManager = networkProfileManager
         self.pingService = pingService
+        self.activityLog = activityLog
         self.userDefaults = userDefaults
         self.sessionStartTime = Date()
 
@@ -128,7 +131,7 @@ final class DashboardViewModel {
 
     /// Recent real events from ToolActivityLog.
     var recentEvents: [ToolActivityItem] {
-        Array(ToolActivityLog.shared.entries.prefix(3))
+        Array(activityLog.entries.prefix(3))
     }
 
     var ispInfo: ISPInfo? {
@@ -147,33 +150,12 @@ final class DashboardViewModel {
         discoveredDevices.count
     }
 
-    // periphery:ignore
     var lastScanDate: Date? {
         deviceDiscoveryService.lastScanDate
     }
 
     var isScanning: Bool {
         deviceDiscoveryService.isScanning
-    }
-
-    // periphery:ignore
-    var activeNetworkLastScanned: Date? {
-        activeNetwork?.lastScanned
-    }
-
-    // periphery:ignore
-    var activeNetworkDeviceCount: Int? {
-        activeNetwork?.deviceCount
-    }
-
-    // periphery:ignore
-    var activeNetworkGatewayReachable: Bool? {
-        activeNetwork?.gatewayReachable
-    }
-
-    // periphery:ignore
-    var isShowingStaleActiveNetworkData: Bool {
-        (activeNetwork?.gatewayReachable == false) && (activeNetwork?.lastScanned != nil)
     }
 
     var sessionDuration: String {
@@ -185,13 +167,6 @@ final class DashboardViewModel {
             return "\(hours)h \(minutes)m"
         }
         return "\(minutes)m"
-    }
-
-    // periphery:ignore
-    var sessionStartTimeFormatted: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h:mm a"
-        return "Today, \(formatter.string(from: sessionStartTime))"
     }
 
     func refresh(forceIP: Bool = false) async {
@@ -208,7 +183,7 @@ final class DashboardViewModel {
             var parts: [String] = []
             if let signal = wifi.signalStrength { parts.append("\(signal)% signal") }
             if let sec = wifi.securityType { parts.append(sec) }
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "WiFi",
                 target: wifi.ssid,
                 result: parts.isEmpty ? "Connected" : parts.joined(separator: " • "),
@@ -233,7 +208,7 @@ final class DashboardViewModel {
             if shouldLog {
                 lastLoggedGatewayLatency = gw.latency
                 let latencyText = gw.latency.map { String(format: "%.0fms", $0) } ?? "timeout"
-                ToolActivityLog.shared.add(
+                activityLog.add(
                     tool: "Gateway",
                     target: gw.ipAddress,
                     result: latencyText,
@@ -300,7 +275,7 @@ final class DashboardViewModel {
         let reachable = anchorLatencies.compactMap { $0.value }
         if !reachable.isEmpty {
             let avg = reachable.reduce(0, +) / Double(reachable.count)
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "Internet",
                 target: "Anchors",
                 result: String(format: "%.0fms avg (%d/%d)", avg, reachable.count, anchorLatencies.count),
@@ -324,7 +299,7 @@ final class DashboardViewModel {
 
         let scoped = scopedDevices(from: deviceDiscoveryService.discoveredDevices)
         let count = scoped.count
-        ToolActivityLog.shared.add(
+        activityLog.add(
             tool: "Scan",
             target: profile?.displayName ?? "Local Network",
             result: "\(count) devices found",
@@ -341,21 +316,6 @@ final class DashboardViewModel {
         }
         defaults.set(count, forKey: AppSettings.Keys.widgetDeviceCount)
         WidgetCenter.shared.reloadTimelines(ofKind: "DeviceGlanceWidget")
-    }
-
-    // periphery:ignore
-    func stopDeviceScan() {
-        deviceDiscoveryService.stopScan()
-    }
-
-    // periphery:ignore
-    func refreshPublicIP() async {
-        await publicIPService.fetchPublicIP(forceRefresh: true)
-    }
-
-    // periphery:ignore
-    func requestLocationPermission() {
-        wifiService.requestLocationPermission()
     }
 
     var needsLocationPermission: Bool {

--- a/NetMonitor-iOS/ViewModels/GeoTraceViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/GeoTraceViewModel.swift
@@ -54,14 +54,17 @@ final class GeoTraceViewModel {
 
     private let tracerouteService: any TracerouteServiceProtocol
     private let geoLocationService: any GeoLocationServiceProtocol
+    private let activityLog: ToolActivityLog
     private var traceTask: Task<Void, Never>?
 
     init(
         tracerouteService: any TracerouteServiceProtocol = TracerouteService(),
-        geoLocationService: any GeoLocationServiceProtocol = GeoLocationService()
+        geoLocationService: any GeoLocationServiceProtocol = GeoLocationService(),
+        activityLog: ToolActivityLog = .shared
     ) {
         self.tracerouteService = tracerouteService
         self.geoLocationService = geoLocationService
+        self.activityLog = activityLog
     }
 
     // MARK: - Computed
@@ -108,7 +111,7 @@ final class GeoTraceViewModel {
             }
 
             isRunning = false
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "Geo Trace",
                 target: trimmedHost,
                 result: "\(hops.count) hops",

--- a/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/HeatmapSurveyViewModel.swift
@@ -492,6 +492,7 @@ final class HeatmapSurveyViewModel {
         project.measurementPoints = state.measurementPoints
         return exporter.exportProjectFile(project: project, fileManager: fileManager)
     }
+
     /// Compatibility wrapper for existing call sites and tests.
     func qualityLabel(_ rssi: Int) -> String {
         RSSIQuality(rssi: rssi).label

--- a/NetMonitor-iOS/ViewModels/PingToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/PingToolViewModel.swift
@@ -34,10 +34,16 @@ final class PingToolViewModel {
     // MARK: - Dependencies
 
     private let pingService: any PingServiceProtocol
+    private let activityLog: ToolActivityLog
     private var pingTask: Task<Void, Never>?
 
-    init(pingService: any PingServiceProtocol = PingService(), initialHost: String? = nil) {
+    init(
+        pingService: any PingServiceProtocol = PingService(),
+        initialHost: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.pingService = pingService
+        self.activityLog = activityLog
         if let initialHost = initialHost {
             self.host = initialHost
         }
@@ -82,7 +88,7 @@ final class PingToolViewModel {
             isRunning = false
 
             if let stats = statistics {
-                ToolActivityLog.shared.add(
+                activityLog.add(
                     tool: "Ping",
                     target: host,
                     result: stats.received > 0 ? "\(String(format: "%.0f", stats.avgTime)) ms avg" : "No response",

--- a/NetMonitor-iOS/ViewModels/PortScannerToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/PortScannerToolViewModel.swift
@@ -29,10 +29,16 @@ final class PortScannerToolViewModel {
     // MARK: - Dependencies
 
     private let portScannerService: any PortScannerServiceProtocol
+    private let activityLog: ToolActivityLog
     private var scanTask: Task<Void, Never>?
 
-    init(portScannerService: any PortScannerServiceProtocol = PortScannerService(), initialHost: String? = nil) {
+    init(
+        portScannerService: any PortScannerServiceProtocol = PortScannerService(),
+        initialHost: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.portScannerService = portScannerService
+        self.activityLog = activityLog
         if let initialHost = initialHost {
             self.host = initialHost
         }
@@ -100,7 +106,7 @@ final class PortScannerToolViewModel {
             results.sort { $0.port < $1.port }
             isRunning = false
 
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "Port Scan",
                 target: host,
                 result: "\(openPorts.count) open / \(totalPorts) scanned",

--- a/NetMonitor-iOS/ViewModels/SpeedTestToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/SpeedTestToolViewModel.swift
@@ -41,10 +41,12 @@ final class SpeedTestToolViewModel {
     // MARK: - Dependencies
 
     private var service: any SpeedTestServiceProtocol
+    private let activityLog: ToolActivityLog
     private var testTask: Task<Void, Never>?
 
-    init(service: any SpeedTestServiceProtocol = SpeedTestService()) {
+    init(service: any SpeedTestServiceProtocol = SpeedTestService(), activityLog: ToolActivityLog = .shared) {
         self.service = service
+        self.activityLog = activityLog
     }
 
     // MARK: - Computed Properties
@@ -112,7 +114,7 @@ final class SpeedTestToolViewModel {
                 modelContext.insert(result)
                 try? modelContext.save()
 
-                ToolActivityLog.shared.add(
+                activityLog.add(
                     tool: "Speed Test",
                     target: data.serverName ?? selectedServer.name,
                     result: "↓\(String(format: "%.0f", data.downloadSpeed)) ↑\(String(format: "%.0f", data.uploadSpeed)) Mbps",
@@ -124,7 +126,7 @@ final class SpeedTestToolViewModel {
             } catch {
                 errorMessage = NetworkError.from(error).userFacingMessage
                 phase = .idle
-                ToolActivityLog.shared.add(
+                activityLog.add(
                     tool: "Speed Test",
                     target: "Server",
                     result: "Failed",

--- a/NetMonitor-iOS/ViewModels/ToolsViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/ToolsViewModel.swift
@@ -5,7 +5,7 @@ import SwiftData
 @MainActor
 @Observable
 final class ToolsViewModel {
-    var recentResults: [ToolActivityItem] { ToolActivityLog.shared.entries }
+    var recentResults: [ToolActivityItem] { activityLog.entries }
     private(set) var isPingRunning = false
     private(set) var isPortScanRunning = false
     private(set) var currentPingResults: [PingResult] = []
@@ -18,6 +18,7 @@ final class ToolsViewModel {
     let wakeOnLANService: any WakeOnLANServiceProtocol
     let deviceDiscoveryService: any DeviceDiscoveryServiceProtocol
     let gatewayService: any GatewayServiceProtocol
+    private let activityLog: ToolActivityLog
 
     init(
         pingService: any PingServiceProtocol = PingService(),
@@ -25,7 +26,8 @@ final class ToolsViewModel {
         dnsLookupService: any DNSLookupServiceProtocol = DNSLookupService(),
         wakeOnLANService: any WakeOnLANServiceProtocol = WakeOnLANService(),
         deviceDiscoveryService: any DeviceDiscoveryServiceProtocol = DeviceDiscoveryService.shared,
-        gatewayService: any GatewayServiceProtocol = GatewayService()
+        gatewayService: any GatewayServiceProtocol = GatewayService(),
+        activityLog: ToolActivityLog = .shared
     ) {
         self.pingService = pingService
         self.portScannerService = portScannerService
@@ -33,6 +35,7 @@ final class ToolsViewModel {
         self.wakeOnLANService = wakeOnLANService
         self.deviceDiscoveryService = deviceDiscoveryService
         self.gatewayService = gatewayService
+        self.activityLog = activityLog
     }
 
     var isScanning: Bool {
@@ -171,11 +174,11 @@ final class ToolsViewModel {
     }
 
     func clearActivity() {
-        ToolActivityLog.shared.clear()
+        activityLog.clear()
     }
 
     private func addActivity(tool: String, target: String, result: String, success: Bool) {
-        ToolActivityLog.shared.add(tool: tool, target: target, result: result, success: success)
+        activityLog.add(tool: tool, target: target, result: result, success: success)
     }
 }
 

--- a/NetMonitor-iOS/ViewModels/TracerouteToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/TracerouteToolViewModel.swift
@@ -31,10 +31,16 @@ final class TracerouteToolViewModel {
     // MARK: - Dependencies
 
     private let tracerouteService: any TracerouteServiceProtocol
+    private let activityLog: ToolActivityLog
     private var traceTask: Task<Void, Never>?
 
-    init(tracerouteService: any TracerouteServiceProtocol = TracerouteService(), initialHost: String? = nil) {
+    init(
+        tracerouteService: any TracerouteServiceProtocol = TracerouteService(),
+        initialHost: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.tracerouteService = tracerouteService
+        self.activityLog = activityLog
         if let initialHost = initialHost {
             self.host = initialHost
         }
@@ -79,7 +85,7 @@ final class TracerouteToolViewModel {
 
             isRunning = false
 
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "Traceroute",
                 target: host,
                 result: "\(hops.count) hops",

--- a/NetMonitor-iOS/ViewModels/WHOISToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/WHOISToolViewModel.swift
@@ -25,9 +25,15 @@ final class WHOISToolViewModel {
     // MARK: - Dependencies
 
     private let whoisService: any WHOISServiceProtocol
+    private let activityLog: ToolActivityLog
 
-    init(whoisService: any WHOISServiceProtocol = WHOISService(), initialDomain: String? = nil) {
+    init(
+        whoisService: any WHOISServiceProtocol = WHOISService(),
+        initialDomain: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.whoisService = whoisService
+        self.activityLog = activityLog
         if let initialDomain = initialDomain {
             self.domain = initialDomain
         }
@@ -55,7 +61,7 @@ final class WHOISToolViewModel {
         let trimmedDomain = domain.trimmingCharacters(in: .whitespaces)
         do {
             result = try await whoisService.lookup(query: trimmedDomain)
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "WHOIS",
                 target: trimmedDomain,
                 result: "Lookup complete",
@@ -63,7 +69,7 @@ final class WHOISToolViewModel {
             )
         } catch {
             errorMessage = NetworkError.from(error).userFacingMessage
-            ToolActivityLog.shared.add(
+            activityLog.add(
                 tool: "WHOIS",
                 target: trimmedDomain,
                 result: "Failed",

--- a/NetMonitor-iOS/ViewModels/WakeOnLANToolViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/WakeOnLANToolViewModel.swift
@@ -19,9 +19,15 @@ final class WakeOnLANToolViewModel {
     // MARK: - Dependencies
 
     private let wolService: any WakeOnLANServiceProtocol
+    private let activityLog: ToolActivityLog
 
-    init(wolService: any WakeOnLANServiceProtocol = WakeOnLANService(), initialMacAddress: String? = nil) {
+    init(
+        wolService: any WakeOnLANServiceProtocol = WakeOnLANService(),
+        initialMacAddress: String? = nil,
+        activityLog: ToolActivityLog = .shared
+    ) {
         self.wolService = wolService
+        self.activityLog = activityLog
         if let initialMacAddress = initialMacAddress {
             self.macAddress = initialMacAddress
         }
@@ -78,7 +84,7 @@ final class WakeOnLANToolViewModel {
             errorMessage = wolService.lastError ?? "Failed to send wake packet"
         }
 
-        ToolActivityLog.shared.add(
+        activityLog.add(
             tool: "Wake on LAN",
             target: macAddress.trimmingCharacters(in: .whitespaces),
             result: success ? "Packet sent" : "Failed",

--- a/NetMonitor-iOS/Views/Components/LabelValueRow.swift
+++ b/NetMonitor-iOS/Views/Components/LabelValueRow.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct LabelValueRow: View {
+    let label: String
+    let value: String
+    var font: Font? = nil
+    var isMonospaced = false
+    var valueSelectionEnabled = true
+    var labelColor: Color = Theme.Colors.textSecondary
+    var valueColor: Color = Theme.Colors.textPrimary
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(font)
+                .foregroundStyle(labelColor)
+
+            Spacer()
+
+            if valueSelectionEnabled {
+                valueText
+                    .textSelection(.enabled)
+            } else {
+                valueText
+            }
+        }
+    }
+
+    private var valueText: some View {
+        Text(value)
+            .font(font)
+            .fontDesign(isMonospaced ? .monospaced : .default)
+            .foregroundStyle(valueColor)
+    }
+}

--- a/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
+++ b/NetMonitor-iOS/Views/DeviceDetail/DeviceDetailView.swift
@@ -536,16 +536,7 @@ struct DeviceDetailView: View {
 
     @ViewBuilder
     private func infoRow(label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .foregroundStyle(Theme.Colors.textSecondary)
-
-            Spacer()
-
-            Text(value)
-                .foregroundStyle(Theme.Colors.textPrimary)
-                .textSelection(.enabled)
-        }
+        LabelValueRow(label: label, value: value)
     }
 
     // MARK: - Helper Functions

--- a/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
+++ b/NetMonitor-iOS/Views/Heatmap/RoomPlanScannerView.swift
@@ -359,15 +359,7 @@ struct RoomPlanScannerView: View {
     }
 
     private func detailRow(label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(Theme.Colors.textSecondary)
-            Spacer()
-            Text(value)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(Theme.Colors.textPrimary)
-        }
+        LabelValueRow(label: label, value: value, font: .caption, isMonospaced: true, valueSelectionEnabled: false)
     }
 
     private func saveToFiles() {
@@ -448,7 +440,6 @@ struct RoomPlanScanContainer: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: RoomPlanScanViewController, context: Context) {}
 }
-
 
 // MARK: - DocumentExporterView
 

--- a/NetMonitor-iOS/Widget/Info.plist
+++ b/NetMonitor-iOS/Widget/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Netmonitor Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.2.1</string>
+	<key>CFBundleVersion</key>
+	<string>10</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+</dict>
+</plist>

--- a/NetMonitor-iOS/Widget/LiveActivity/LiveActivityViews.swift
+++ b/NetMonitor-iOS/Widget/LiveActivity/LiveActivityViews.swift
@@ -247,13 +247,6 @@ struct MonitoringCompactTrailingView: View {
 }
 
 // MARK: - Live Activity Widget Configurations
-// NOTE: To enable Live Activities, add these to NetmonitorWidgetBundle.body in NetmonitorWidget.swift:
-//   NetmonitorNetworkScanActivity()
-//   NetmonitorSpeedTestActivity()
-//   NetmonitorMonitoringActivity()
-//
-// Also set NSSupportsLiveActivities = YES in the widget extension Info.plist
-// and add the ActivityKit capability to the widget extension target in project.yml.
 
 struct NetmonitorNetworkScanActivity: Widget {
     var body: some WidgetConfiguration {

--- a/NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements
+++ b/NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.blakemiller.netmonitor</string>
+    </array>
+</dict>
+</plist>

--- a/NetMonitor-iOS/Widget/NetmonitorWidget.swift
+++ b/NetMonitor-iOS/Widget/NetmonitorWidget.swift
@@ -423,6 +423,9 @@ struct NetmonitorWidgetBundle: WidgetBundle {
     var body: some Widget {
         NetmonitorWidget()
         DeviceGlanceWidget()
+        NetmonitorNetworkScanActivity()
+        NetmonitorSpeedTestActivity()
+        NetmonitorMonitoringActivity()
     }
 }
 

--- a/NetMonitor-macOS/Platform/CompanionService.swift
+++ b/NetMonitor-macOS/Platform/CompanionService.swift
@@ -24,6 +24,24 @@ actor CompanionService {
     let serviceType = "_netmon._tcp"
     let serviceName = "NetMonitor"
 
+    /// Dedicated callback queue for NWListener.
+    /// `NWListener.start(queue:)` requires a `DispatchQueue` (Apple API);
+    /// using a named queue instead of `.global()` keeps thread dumps
+    /// attributable and pins callbacks to a known QoS.
+    let listenerQueue = DispatchQueue(
+        label: "com.netmonitor.companion.listener",
+        qos: .userInitiated
+    )
+
+    /// Shared callback queue for accepted `NWConnection`s.
+    /// Concurrent so per-client receive/send callbacks don't serialize behind
+    /// each other; named so thread attribution survives into client work.
+    let connectionQueue = DispatchQueue(
+        label: "com.netmonitor.companion.connection",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
     private(set) var isRunning = false
     private(set) var connectedClients: [UUID: NWConnection] = [:]
     private var clientInfos: [UUID: ConnectedClientInfo] = [:]
@@ -43,14 +61,17 @@ actor CompanionService {
     func start(messageHandler: @escaping (CompanionMessage, UUID) async -> CompanionMessage?) throws {
         guard !isRunning else { return }
 
-        self.messageHandler = messageHandler
-
-        // Create listener — plain TCP, no custom framer
+        // Create listener — plain TCP, no custom framer.
+        // Construct *before* storing `messageHandler` so a thrown error doesn't
+        // leak the captured closure into the actor.
         let parameters = NWParameters.tcp
         parameters.includePeerToPeer = true
 
         // swiftlint:disable:next force_unwrapping
-        listener = try NWListener(using: parameters, on: NWEndpoint.Port(rawValue: port)!)
+        let newListener = try NWListener(using: parameters, on: NWEndpoint.Port(rawValue: port)!)
+
+        self.messageHandler = messageHandler
+        listener = newListener
 
         // Advertise via Bonjour
         let txtRecord = NWTXTRecord()
@@ -73,7 +94,7 @@ actor CompanionService {
             }
         }
 
-        listener?.start(queue: .global())
+        listener?.start(queue: listenerQueue)
         isRunning = true
     }
 
@@ -145,7 +166,7 @@ actor CompanionService {
             }
         }
 
-        connection.start(queue: .global())
+        connection.start(queue: connectionQueue)
         receiveMessage(from: connection, clientID: clientID)
     }
 

--- a/NetMonitor-macOS/Platform/WiFiHeatmapService.swift
+++ b/NetMonitor-macOS/Platform/WiFiHeatmapService.swift
@@ -34,19 +34,19 @@ struct SignalSnapshot {
 /// can be exercised with stubs in tests.
 protocol MacWiFiSignalProviding: Sendable {
     @MainActor func currentSignal() -> SignalSnapshot?
-    func scanForNearbyAPs() -> [NearbyAP]
+    func scanForNearbyAPs() async -> [NearbyAP]
 }
 
 // MARK: - WiFiHeatmapService
 
 /// CoreWLAN wrapper providing live signal data and nearby AP scanning for the heatmap tool.
 /// `currentSignal()` is fast and called on @MainActor from the poll loop.
-/// `scanForNearbyAPs()` is blocking (3-10s) and nonisolated — callers must dispatch it
-/// off the main thread via Task.detached.
+/// `scanForNearbyAPs()` is async because CoreWLAN's scan call can block for several seconds.
 @MainActor
 final class WiFiHeatmapService: MacWiFiSignalProviding, @unchecked Sendable {
 
     nonisolated let interfaceName: String?
+    nonisolated private let scanQueue = DispatchQueue(label: "com.netmonitor.wifi-heatmap.scan", qos: .userInitiated)
 
     init() {
         interfaceName = CWWiFiClient.shared().interface()?.interfaceName
@@ -87,7 +87,15 @@ final class WiFiHeatmapService: MacWiFiSignalProviding, @unchecked Sendable {
 
     // MARK: - Nearby AP Scan
 
-    nonisolated func scanForNearbyAPs() -> [NearbyAP] {
+    nonisolated func scanForNearbyAPs() async -> [NearbyAP] {
+        await withCheckedContinuation { continuation in
+            scanQueue.async {
+                continuation.resume(returning: self.performNearbyAPScan())
+            }
+        }
+    }
+
+    nonisolated private func performNearbyAPScan() -> [NearbyAP] {
         guard let iface else { return [] }
         do {
             let networks = try iface.scanForNetworks(withName: nil)

--- a/NetMonitor-macOS/Resources/Info.plist
+++ b/NetMonitor-macOS/Resources/Info.plist
@@ -44,9 +44,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>30</string>
+	<string>1779160181</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/NetMonitor-macOS/ViewModels/WiFiHeatmapViewModel.swift
+++ b/NetMonitor-macOS/ViewModels/WiFiHeatmapViewModel.swift
@@ -201,13 +201,10 @@ final class WiFiHeatmapViewModel {
         guard !isScanning else { return }
         isScanning = true
         let service = heatmapService
-        Task.detached {
-            // CWInterface.scanForNetworks is a blocking call (3-10s) — run off main thread
-            let aps = service.scanForNearbyAPs()
-            await MainActor.run { [weak self] in
-                self?.nearbyAPs = aps
-                self?.isScanning = false
-            }
+        Task { [weak self] in
+            let aps = await service.scanForNearbyAPs()
+            self?.nearbyAPs = aps
+            self?.isScanning = false
         }
     }
 

--- a/NetMonitor-macOS/Views/Components/LabelValueRow.swift
+++ b/NetMonitor-macOS/Views/Components/LabelValueRow.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct LabelValueRow: View {
+    let label: String
+    let value: String
+    var labelWidth: CGFloat?
+    var labelAlignment: Alignment = .leading
+    var rowAlignment: VerticalAlignment = .center
+    var labelFont: Font? = nil
+    var valueFont: Font? = nil
+    var isMonospaced = false
+    var isCopyable = false
+    var valueSelectionEnabled = true
+    var valueColor: Color = .primary
+    var valueLineLimit: Int?
+
+    var body: some View {
+        HStack(alignment: rowAlignment, spacing: 8) {
+            Text(label)
+                .font(labelFont)
+                .foregroundStyle(.secondary)
+                .frame(width: labelWidth, alignment: labelAlignment)
+                .layoutPriority(1)
+
+            if valueSelectionEnabled {
+                valueText
+                    .textSelection(.enabled)
+            } else {
+                valueText
+            }
+
+            if isCopyable {
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(value, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("labelValueRow_button_copy_\(label.lowercased().replacingOccurrences(of: " ", with: "_"))")
+            }
+
+            Spacer(minLength: 8)
+        }
+    }
+
+    private var valueText: some View {
+        Text(value)
+            .font(valueFont)
+            .fontDesign(isMonospaced ? .monospaced : .default)
+            .foregroundStyle(valueColor)
+            .lineLimit(valueLineLimit)
+            .truncationMode(.middle)
+    }
+}

--- a/NetMonitor-macOS/Views/DeviceDetailView.swift
+++ b/NetMonitor-macOS/Views/DeviceDetailView.swift
@@ -421,17 +421,7 @@ struct DeviceDetailView: View {
     // MARK: - Helper Views
 
     private func infoRow(label: String, value: String, monospace: Bool = false) -> some View {
-        HStack {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .layoutPriority(1)
-            Spacer(minLength: 8)
-            Text(value)
-                .fontDesign(monospace ? .monospaced : .default)
-                .textSelection(.enabled)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
+        LabelValueRow(label: label, value: value, isMonospaced: monospace, valueLineLimit: 1)
     }
 
     private func actionButton(

--- a/NetMonitor-macOS/Views/Devices/ProDeviceDetailView.swift
+++ b/NetMonitor-macOS/Views/Devices/ProDeviceDetailView.swift
@@ -421,39 +421,16 @@ private extension ProDeviceDetailView {
     }
 
     func detailRow(_ label: String, _ value: String, mono: Bool = false, copyable: Bool = false, valueColor: Color? = nil) -> some View {
-        HStack(spacing: 8) {
-            Text(label)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .frame(width: 100, alignment: .leading)
-
-            Group {
-                if mono {
-                    Text(value)
-                        .fontDesign(.monospaced)
-                } else {
-                    Text(value)
-                }
-            }
-            .font(.subheadline)
-            .foregroundStyle(valueColor ?? .primary)
-            .textSelection(.enabled)
-
-            if copyable {
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(value, forType: .string)
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("deviceDetail_button_copy_\(label.lowercased().replacingOccurrences(of: " ", with: "_"))")
-            }
-
-            Spacer()
-        }
+        LabelValueRow(
+            label: label,
+            value: value,
+            labelWidth: 100,
+            labelFont: .subheadline,
+            valueFont: .subheadline,
+            isMonospaced: mono,
+            isCopyable: copyable,
+            valueColor: valueColor ?? .primary
+        )
     }
 
     // MARK: - Helpers

--- a/NetMonitor-macOS/Views/Heatmap/HeatmapSidebarView.swift
+++ b/NetMonitor-macOS/Views/Heatmap/HeatmapSidebarView.swift
@@ -347,15 +347,7 @@ struct HeatmapSidebarView: View {
     }
 
     private func infoRow(_ label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text(value)
-                .font(.caption)
-                .foregroundStyle(.primary)
-        }
+        LabelValueRow(label: label, value: value, labelFont: .caption, valueFont: .caption, valueSelectionEnabled: false)
     }
 
     private func signalBars(rssi: Int) -> some View {

--- a/NetMonitor-macOS/Views/Tools/BonjourBrowserToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/BonjourBrowserToolView.swift
@@ -221,17 +221,15 @@ struct BonjourBrowserToolView: View {
     }
 
     private func detailRow(label: String, value: String) -> some View {
-        HStack(alignment: .top) {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .frame(width: 100, alignment: .trailing)
-
-            Text(value)
-                .font(.system(.body, design: .monospaced))
-                .textSelection(.enabled)
-
-            Spacer()
-        }
+        LabelValueRow(
+            label: label,
+            value: value,
+            labelWidth: 100,
+            labelAlignment: .trailing,
+            rowAlignment: .top,
+            valueFont: .body,
+            isMonospaced: true
+        )
     }
 
     // MARK: - Footer

--- a/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
+++ b/NetMonitor-macOS/Views/Tools/SSLCertificateMonitorView.swift
@@ -298,10 +298,16 @@ struct SSLCertificateMonitorView: View {
     }
 
     private func infoRow(_ label: String, _ value: String) -> some View {
-        HStack(alignment: .top) {
-            Text(label).font(.caption).foregroundStyle(.secondary).frame(width: 90, alignment: .leading)
-            Text(value).font(.caption).fontDesign(.monospaced)
-        }
+        LabelValueRow(
+            label: label,
+            value: value,
+            labelWidth: 90,
+            rowAlignment: .top,
+            labelFont: .caption,
+            valueFont: .caption,
+            isMonospaced: true,
+            valueSelectionEnabled: false
+        )
     }
 
     private func expiryColor(days: Int) -> Color {

--- a/NetMonitor-macOS/Views/Tools/SubnetCalculatorToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/SubnetCalculatorToolView.swift
@@ -135,14 +135,7 @@ struct SubnetCalculatorToolView: View {
     }
 
     private func infoRow(_ label: String, _ value: String) -> some View {
-        HStack(alignment: .top) {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .frame(width: 140, alignment: .leading)
-            Text(value)
-                .textSelection(.enabled)
-                .font(.system(.body, design: .monospaced))
-        }
+        LabelValueRow(label: label, value: value, labelWidth: 140, rowAlignment: .top, valueFont: .body, isMonospaced: true)
     }
 
     // MARK: - Footer

--- a/NetMonitor-macOS/Views/Tools/WHOISToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/WHOISToolView.swift
@@ -194,14 +194,7 @@ struct WHOISToolView: View {
     }
 
     private func infoRow(_ label: String, _ value: String) -> some View {
-        HStack(alignment: .top) {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .frame(width: 120, alignment: .leading)
-            Text(value)
-                .textSelection(.enabled)
-                .font(.system(.body, design: .monospaced))
-        }
+        LabelValueRow(label: label, value: value, labelWidth: 120, rowAlignment: .top, valueFont: .body, isMonospaced: true)
     }
 
     // MARK: - Footer

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/CompanionMessage.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/CompanionMessage.swift
@@ -3,9 +3,11 @@ import Foundation
 // MARK: - CompanionMessage
 /// Root message type for macOS ↔ iOS companion communication.
 /// Uses length-prefixed JSON framing: 4-byte big-endian length prefix + JSON payload.
-/// JSON format: { "type": "<messageType>", "payload": { ... } }
+/// JSON format: { "protocolVersion": 1, "type": "<messageType>", "payload": { ... } }
 
 public enum CompanionMessage: Codable, Sendable {
+    public static let currentProtocolVersion = 1
+
     case statusUpdate(StatusUpdatePayload)
     case targetList(TargetListPayload)
     case deviceList(DeviceListPayload)
@@ -18,6 +20,7 @@ public enum CompanionMessage: Codable, Sendable {
     // MARK: Coding Keys
 
     private enum CodingKeys: String, CodingKey {
+        case protocolVersion
         case type
         case payload
     }
@@ -37,6 +40,13 @@ public enum CompanionMessage: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let protocolVersion = try container.decodeIfPresent(Int.self, forKey: .protocolVersion) ?? Self.currentProtocolVersion
+        guard protocolVersion == Self.currentProtocolVersion else {
+            throw CompanionMessageDecodeError.versionMismatch(
+                got: protocolVersion,
+                expected: Self.currentProtocolVersion
+            )
+        }
         let type = try container.decode(MessageType.self, forKey: .type)
 
         switch type {
@@ -63,6 +73,7 @@ public enum CompanionMessage: Codable, Sendable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.currentProtocolVersion, forKey: .protocolVersion)
 
         switch self {
         case .statusUpdate(let payload):
@@ -89,6 +100,17 @@ public enum CompanionMessage: Codable, Sendable {
         case .heartbeat(let payload):
             try container.encode(MessageType.heartbeat, forKey: .type)
             try container.encode(payload, forKey: .payload)
+        }
+    }
+}
+
+public enum CompanionMessageDecodeError: Error, Equatable, LocalizedError, Sendable {
+    case versionMismatch(got: Int, expected: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .versionMismatch(let got, let expected):
+            return "Companion protocol version mismatch: got \(got), expected \(expected)"
         }
     }
 }

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/ToolActivityLog.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Models/ToolActivityLog.swift
@@ -41,7 +41,7 @@ public final class ToolActivityLog {
     public private(set) var entries: [ToolActivityItem] = []
     private let maxEntries = 20
 
-    private init() {}
+    public init() {}
 
     public func add(tool: String, target: String, result: String, success: Bool) {
         let item = ToolActivityItem(

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/MACVendorLookupService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/MACVendorLookupService.swift
@@ -16,10 +16,6 @@ public actor MACVendorLookupService: MACVendorLookupServiceProtocol {
         self.session = session
     }
 
-    // MARK: - Protocol conformance
-    /// MACVendorLookupServiceProtocol: async lookup (delegates to enhanced lookup)
-    // Implemented as lookupVendorEnhanced below
-
     // MARK: - Properties
 
     /// URLSession used for online OUI API lookups.
@@ -208,19 +204,20 @@ public actor MACVendorLookupService: MACVendorLookupServiceProtocol {
 
     // MARK: - Public Methods
 
-    /// Look up vendor using online API first, then local database as fallback
+    /// Look up vendor using the local database first, then online API as fallback.
     /// - Parameter macAddress: MAC address in any format (colons, dashes, or none)
     /// - Returns: Vendor name if found
     public func lookupVendorEnhanced(macAddress: String) async -> String? {
-        // Try online API first
+        if let localVendor = lookup(macAddress: macAddress) {
+            return localVendor
+        }
+
         if let vendor = await lookupVendorOnline(macAddress: macAddress) {
-            // Cache the result
             cacheResult(macAddress: macAddress, vendor: vendor)
             return vendor
         }
 
-        // Fall back to local OUI database
-        return lookup(macAddress: macAddress)
+        return nil
     }
 
     /// Look up the vendor for a MAC address (local database only)

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/ServiceProtocols.swift
@@ -95,8 +95,17 @@ public protocol WakeOnLANServiceProtocol: AnyObject, Sendable {
     @MainActor func wake(macAddress: String, broadcastAddress: String, port: UInt16) async -> Bool
 }
 
-/// Protocol for speed test operations.
-public protocol SpeedTestServiceProtocol: Sendable {
+/// Commands required to run and stop speed tests.
+public protocol SpeedTestRunnerProtocol: Sendable {
+    @MainActor var duration: TimeInterval { get set }
+    /// The server to use for the next test run. `nil` means auto-select (Cloudflare default).
+    @MainActor var selectedServer: SpeedTestServer? { get set }
+    @MainActor func startTest() async throws -> SpeedTestData
+    @MainActor func stopTest()
+}
+
+/// Read-only state exposed by a speed test run.
+public protocol SpeedTestStateProtocol: Sendable {
     @MainActor var downloadSpeed: Double { get }
     @MainActor var uploadSpeed: Double { get }
     @MainActor var peakDownloadSpeed: Double { get }
@@ -107,12 +116,10 @@ public protocol SpeedTestServiceProtocol: Sendable {
     @MainActor var phase: SpeedTestPhase { get }
     @MainActor var isRunning: Bool { get }
     @MainActor var errorMessage: String? { get }
-    @MainActor var duration: TimeInterval { get set }
-    /// The server to use for the next test run. `nil` means auto-select (Cloudflare default).
-    @MainActor var selectedServer: SpeedTestServer? { get set }
-    @MainActor func startTest() async throws -> SpeedTestData
-    @MainActor func stopTest()
 }
+
+/// Protocol for speed test operations.
+public protocol SpeedTestServiceProtocol: SpeedTestRunnerProtocol, SpeedTestStateProtocol {}
 
 /// Protocol for network path monitoring.
 public protocol NetworkMonitorServiceProtocol: AnyObject, Sendable {

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Utilities/ResumeState.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Utilities/ResumeState.swift
@@ -1,25 +1,4 @@
-import Foundation
+import NetworkScanKit
 
-/// A thread-safe helper actor for managing single-use continuation state.
-/// Prevents multiple resumes of a CheckedContinuation in async/await patterns.
-///
-/// Also available in the NetworkScanKit package; provided here for services
-/// in NetMonitorCore that need it without a NetworkScanKit import.
-public actor ResumeState {
-    public private(set) var hasResumed = false
-
-    public init() {}
-
-    public func setResumed() {
-        hasResumed = true
-    }
-
-    /// Atomically checks and sets the resumed flag.
-    /// Returns `true` if this call was the first to resume (safe to proceed),
-    /// or `false` if already resumed (should bail out).
-    public func tryResume() -> Bool {
-        if hasResumed { return false }
-        hasResumed = true
-        return true
-    }
-}
+/// Compatibility alias for the canonical NetworkScanKit continuation guard.
+public typealias ResumeState = NetworkScanKit.ResumeState

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/CompanionMessageTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/CompanionMessageTests.swift
@@ -374,6 +374,33 @@ struct CompanionMessageAdditionalCasesTests {
         #expect(p.devices[0].ipAddress == "10.0.0.5")
     }
 
+    // MARK: - Protocol Version
+
+    @Test func encodedMessageIncludesProtocolVersion() throws {
+        let msg = CompanionMessage.heartbeat(HeartbeatPayload(version: "2.0"))
+        let data = try CompanionMessage.jsonEncoder.encode(msg)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["protocolVersion"] as? Int == CompanionMessage.currentProtocolVersion)
+    }
+
+    @Test func decodeThrowsVersionMismatchForUnsupportedProtocolVersion() {
+        let unsupportedVersion = CompanionMessage.currentProtocolVersion + 1
+        let json = """
+        {
+          "protocolVersion": \(unsupportedVersion),
+          "type": "heartbeat",
+          "payload": {
+            "timestamp": "2026-05-18T00:00:00Z",
+            "version": "2.0"
+          }
+        }
+        """
+
+        #expect(throws: CompanionMessageDecodeError.versionMismatch(got: unsupportedVersion, expected: CompanionMessage.currentProtocolVersion)) {
+            _ = try CompanionMessage.decode(from: Data(json.utf8))
+        }
+    }
+
     // MARK: - Malformed JSON
 
     @Test func malformedJsonThrowsDecodingError() {

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/DeviceTypeInferenceServiceTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/DeviceTypeInferenceServiceTests.swift
@@ -22,6 +22,7 @@ private func makeDevice(
         vendor: vendor,
         deviceType: deviceType,
         customName: customName,
+        isGateway: isGateway,
         resolvedHostname: resolvedHostname,
         manufacturer: manufacturer,
         openPorts: openPorts,

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/HeatmapModelsTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/HeatmapModelsTests.swift
@@ -417,9 +417,9 @@ struct HeatmapVisualizationTests {
 
     // MARK: - valueRange
 
-    @Test("signalStrength valueRange is -100...0")
+    @Test("signalStrength valueRange is -85...-25")
     func signalStrengthValueRange() {
-        #expect(HeatmapVisualization.signalStrength.valueRange == -100.0...0.0)
+        #expect(HeatmapVisualization.signalStrength.valueRange == -85.0 ... -25.0)
     }
 
     @Test("latency valueRange is 0...200")

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/HeatmapRendererTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/HeatmapRendererTests.swift
@@ -224,14 +224,14 @@ struct HeatmapRendererColorTests {
     @Test("strong signal maps to green range")
     func strongSignalIsGreen() {
         let renderer = makeRenderer()
-        let color = renderer.colorForValue(-30, visualization: .signalStrength)
+        let color = renderer.colorForValue(-30, visualization: .signalStrength, colorScheme: .wifiman)
         #expect(color.g > color.r, "Strong signal should have more green than red")
     }
 
     @Test("weak signal maps to red range")
     func weakSignalIsRed() {
         let renderer = makeRenderer()
-        let color = renderer.colorForValue(-95, visualization: .signalStrength)
+        let color = renderer.colorForValue(-95, visualization: .signalStrength, colorScheme: .wifiman)
         #expect(color.r > color.g, "Weak signal should have more red than green")
     }
 
@@ -265,8 +265,8 @@ struct HeatmapRendererColorTests {
     @Test("latency color inverts direction (lower is better)")
     func latencyColorInversion() {
         let renderer = makeRenderer()
-        let lowLatency = renderer.colorForValue(5, visualization: .latency)
-        let highLatency = renderer.colorForValue(150, visualization: .latency)
+        let lowLatency = renderer.colorForValue(5, visualization: .latency, colorScheme: .wifiman)
+        let highLatency = renderer.colorForValue(150, visualization: .latency, colorScheme: .wifiman)
         #expect(lowLatency.g > lowLatency.r, "Low latency (good) should be more green")
         #expect(highLatency.r > highLatency.g, "High latency (bad) should be more red")
     }

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/NWConnectionHelper.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/NWConnectionHelper.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Network
+
+/// Outcome the classifier in ``withNWConnection(_:on:timeout:timeoutValue:classify:)``
+/// returns for a given state transition.
+enum NWConnectionResolution<T: Sendable> {
+    /// Resolve and cancel the connection.
+    case complete(T)
+    /// Resolve and leave the connection running so the caller can keep using it
+    /// (e.g. send/receive after `.ready`).
+    case completeKeepAlive(T)
+}
+
+/// Awaits the first relevant state transition on `connection` and returns the value
+/// produced by `classify`, or `timeoutValue` after `timeout` elapses.
+///
+/// Wraps the recurring scan-phase pattern: start the connection on `queue`, race
+/// state-handler callbacks against a timeout, and ensure exactly one resolution wins.
+/// The classifier inspects each `NWConnection.State` and returns either a final
+/// resolution or `nil` to keep waiting for further transitions.
+///
+/// On timeout and on `.complete(_)` the connection is cancelled before the helper
+/// returns. `.completeKeepAlive(_)` skips cancellation so the caller can continue
+/// using the live connection. The caller passes a freshly-constructed `NWConnection`
+/// that has not yet been started.
+func withNWConnection<T: Sendable>(
+    _ connection: NWConnection,
+    on queue: DispatchQueue = scanQueue,
+    timeout: Duration,
+    timeoutValue: T,
+    classify: @escaping @Sendable (NWConnection.State) -> NWConnectionResolution<T>?
+) async -> T {
+    await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
+        let resumed = ResumeState()
+
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            guard await resumed.tryResume() else { return }
+            connection.cancel()
+            continuation.resume(returning: timeoutValue)
+        }
+
+        connection.stateUpdateHandler = { state in
+            guard let resolution = classify(state) else { return }
+            Task {
+                guard await resumed.tryResume() else { return }
+                timeoutTask.cancel()
+                switch resolution {
+                case .complete(let value):
+                    connection.cancel()
+                    continuation.resume(returning: value)
+                case .completeKeepAlive(let value):
+                    continuation.resume(returning: value)
+                }
+            }
+        }
+
+        connection.start(queue: queue)
+    }
+}

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/BonjourScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/BonjourScanPhase.swift
@@ -170,50 +170,20 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
         let params = NWParameters.tcp
         let connection = NWConnection(to: endpoint, using: params)
 
-        let result: String? = await withCheckedContinuation { continuation in
-            let resumed = ResumeState()
-
-            let timeoutTask = Task {
-                try? await Task.sleep(for: .seconds(2))
-                guard await resumed.tryResume() else { return }
-                connection.cancel()
-                continuation.resume(returning: nil)
-            }
-
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    let resolvedHost: String?
-                    if let innerEndpoint = connection.currentPath?.remoteEndpoint,
-                       case let .hostPort(host, _) = innerEndpoint {
-                        resolvedHost = "\(host)"
-                    } else {
-                        resolvedHost = nil
-                    }
-
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: resolvedHost)
-                    }
-                case .failed, .cancelled:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: nil)
-                    }
-                default:
-                    break
+        return await withNWConnection(connection, timeout: .seconds(2), timeoutValue: nil) { state in
+            switch state {
+            case .ready:
+                if let innerEndpoint = connection.currentPath?.remoteEndpoint,
+                   case let .hostPort(host, _) = innerEndpoint {
+                    return .complete("\(host)")
                 }
+                return .complete(nil)
+            case .failed, .cancelled:
+                return .complete(nil)
+            default:
+                return nil
             }
-
-            connection.start(queue: scanQueue)
         }
-
-        connection.cancel()
-        return result
     }
 
     private static func resolveIPv4Addresses(for host: String) async -> [String] {

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/SSDPScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/SSDPScanPhase.swift
@@ -64,42 +64,16 @@ public struct SSDPScanPhase: ScanPhase, Sendable {
         let connection = NWConnection(to: endpoint, using: params)
 
         // Wait for connection ready (with timeout to prevent hang).
-        let ready: Bool = await withCheckedContinuation { continuation in
-            let resumed = ResumeState()
-
-            let timeoutTask = Task {
-                try? await Task.sleep(for: .seconds(2))
-                guard await resumed.tryResume() else { return }
-                connection.cancel()
-                continuation.resume(returning: false)
+        // Keep the connection alive on .ready so the send/receive loop below can use it.
+        let ready = await withNWConnection(connection, timeout: .seconds(2), timeoutValue: false) { state in
+            switch state {
+            case .ready: return .completeKeepAlive(true)
+            case .failed, .cancelled: return .complete(false)
+            default: return nil
             }
-
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        continuation.resume(returning: true)
-                    }
-                case .failed, .cancelled:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: false)
-                    }
-                default:
-                    break
-                }
-            }
-            connection.start(queue: scanQueue)
         }
 
-        guard ready else {
-            connection.cancel()
-            return []
-        }
+        guard ready else { return [] }
 
         // Send M-SEARCH
         connection.send(content: messageData, completion: .contentProcessed { _ in })

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
@@ -7,16 +7,6 @@ import Network
 /// Uses adaptive RTT-based timeouts that converge from conservative base values
 /// to network-appropriate timeouts as successful connections are observed.
 public struct TCPProbeScanPhase: ScanPhase, Sendable {
-    /// Reference-type timestamp for Sendable closure capture.
-    ///
-    /// SAFETY: @unchecked Sendable is safe here because each DateRef instance is created
-    /// and read within a single NWConnection callback scope on scanQueue. The value is
-    /// written once at construction and read once when the connection state fires —
-    /// no concurrent access occurs.
-    private final class DateRef: @unchecked Sendable {
-        var value = Date()
-    }
-
     public let id = "tcpProbe"
     public let displayName = "Probing ports…"
     public let weight: Double = 0.55
@@ -220,57 +210,25 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         params.requiredInterfaceType = .wifi
 
         let connection = NWConnection(to: endpoint, using: params)
+        let startTime = Date()
 
-        let result = await withCheckedContinuation { (continuation: CheckedContinuation<PortProbeOutcome, Never>) in
-            let resumed = ResumeState()
-            let startTime = DateRef()
-
-            let timeoutTask = Task {
-                try? await Task.sleep(for: timeout)
-                guard await resumed.tryResume() else { return }
-                connection.cancel()
-                continuation.resume(returning: .timeout)
-            }
-
-            connection.stateUpdateHandler = { state in
-                let elapsed = Date().timeIntervalSince(startTime.value) * 1000
-                switch state {
-                case .ready:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: .reachable(latency: elapsed))
-                    }
-                case .failed(let error):
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-
-                        if case NWError.posix(let code) = error, code == .ECONNREFUSED {
-                            continuation.resume(returning: .refused(latency: elapsed))
-                        } else {
-                            continuation.resume(returning: .failed)
-                        }
-                    }
-                case .cancelled:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: .failed)
-                    }
-                default:
-                    break
+        let result: PortProbeOutcome = await withNWConnection(connection, timeout: timeout, timeoutValue: .timeout) { state in
+            let elapsed = Date().timeIntervalSince(startTime) * 1000
+            switch state {
+            case .ready:
+                return .complete(.reachable(latency: elapsed))
+            case .failed(let error):
+                if case NWError.posix(let code) = error, code == .ECONNREFUSED {
+                    return .complete(.refused(latency: elapsed))
                 }
+                return .complete(.failed)
+            case .cancelled:
+                return .complete(.failed)
+            default:
+                return nil
             }
-
-            startTime.value = Date()
-            connection.start(queue: scanQueue)
         }
 
-        connection.cancel()
         // Release synchronously *before* return so the next acquire() sees the
         // released slot. Wrapping in `Task { ... }` (the old `defer { Task { ... } }`
         // pattern) detaches release into a later async context, so callers can pile
@@ -372,67 +330,30 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         params.requiredInterfaceType = .wifi
 
         let connection = NWConnection(to: endpoint, using: params)
+        let startTime = Date()
 
-        let result: Double? = await withCheckedContinuation { (continuation: CheckedContinuation<Double?, Never>) in
-            let resumed = ResumeState()
-            let startTime = DateRef()
-
-            let timeoutTask = Task {
-                try? await Task.sleep(for: timeout)
-                guard await resumed.tryResume() else { return }
-                connection.cancel()
-                continuation.resume(returning: nil)
-            }
-
-            connection.stateUpdateHandler = { state in
-                let elapsed = Date().timeIntervalSince(startTime.value) * 1000
-                switch state {
-                case .ready:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: elapsed)
-                    }
-                case .failed(let error):
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        if case NWError.posix(let code) = error, code == .ECONNREFUSED {
-                            continuation.resume(returning: elapsed)
-                        } else {
-                            continuation.resume(returning: nil)
-                        }
-                    }
-                case .cancelled:
-                    Task {
-                        guard await resumed.tryResume() else { return }
-                        timeoutTask.cancel()
-                        connection.cancel()
-                        continuation.resume(returning: nil)
-                    }
-                case .waiting(let error):
-                    // Some devices report ECONNREFUSED in .waiting rather than .failed.
-                    // The RST still proves reachability, so capture the latency.
-                    if case NWError.posix(let code) = error, code == .ECONNREFUSED {
-                        Task {
-                            guard await resumed.tryResume() else { return }
-                            timeoutTask.cancel()
-                            connection.cancel()
-                            continuation.resume(returning: elapsed)
-                        }
-                    }
-                default:
-                    break
+        return await withNWConnection(connection, timeout: timeout, timeoutValue: nil) { state in
+            let elapsed = Date().timeIntervalSince(startTime) * 1000
+            switch state {
+            case .ready:
+                return .complete(elapsed)
+            case .failed(let error):
+                if case NWError.posix(let code) = error, code == .ECONNREFUSED {
+                    return .complete(elapsed)
                 }
+                return .complete(nil)
+            case .cancelled:
+                return .complete(nil)
+            case .waiting(let error):
+                // Some devices report ECONNREFUSED in .waiting rather than .failed.
+                // The RST still proves reachability, so capture the latency.
+                if case NWError.posix(let code) = error, code == .ECONNREFUSED {
+                    return .complete(elapsed)
+                }
+                return nil
+            default:
+                return nil
             }
-
-            startTime.value = Date()
-            connection.start(queue: scanQueue)
         }
-
-        connection.cancel()
-        return result
     }
 }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/BonjourScanPhaseTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/BonjourScanPhaseTests.swift
@@ -51,7 +51,7 @@ struct BonjourScanPhaseTests {
     func initWithStopProvider() {
         let phase = BonjourScanPhase(
             serviceProvider: { [] },
-            stopProvider: { }
+            stopProvider: {}
         )
         #expect(phase.id == "bonjour")
     }

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/NWConnectionHelperTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/NWConnectionHelperTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Network
+import Testing
+@testable import NetworkScanKit
+
+@Suite("withNWConnection")
+struct NWConnectionHelperTests {
+
+    @Test("returns timeoutValue when classify never resolves")
+    func timeoutPath() async {
+        // Endpoint is intentionally unreachable (RFC 5737 TEST-NET-1) so the
+        // connection cannot transition to a state classify treats as terminal
+        // within the timeout window.
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host("192.0.2.1"),
+            port: NWEndpoint.Port(rawValue: 65535)!
+        )
+        let params = NWParameters.tcp
+        params.requiredInterfaceType = .wifi
+        let connection = NWConnection(to: endpoint, using: params)
+
+        let result = await withNWConnection(
+            connection,
+            timeout: .milliseconds(100),
+            timeoutValue: "timed-out"
+        ) { state in
+            // Never resolve from any state — force the timeout path.
+            _ = state
+            return nil
+        }
+
+        #expect(result == "timed-out")
+    }
+
+    @Test("classify returning .complete returns the value")
+    func completePathResolves() async {
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host("127.0.0.1"),
+            port: NWEndpoint.Port(rawValue: 9)!
+        )
+        let connection = NWConnection(to: endpoint, using: .udp)
+
+        let result = await withNWConnection(
+            connection,
+            timeout: .seconds(2),
+            timeoutValue: "timeout"
+        ) { state in
+            switch state {
+            case .ready: return .complete("ready")
+            case .failed, .cancelled: return .complete("error")
+            default: return nil
+            }
+        }
+
+        #expect(result == "ready" || result == "error")
+        #expect(result != "timeout")
+    }
+
+    @Test("classify returning .completeKeepAlive returns value without cancelling")
+    func keepAlivePathLeavesConnection() async {
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host("127.0.0.1"),
+            port: NWEndpoint.Port(rawValue: 9)!
+        )
+        let connection = NWConnection(to: endpoint, using: .udp)
+
+        let result = await withNWConnection(
+            connection,
+            timeout: .seconds(2),
+            timeoutValue: false
+        ) { state in
+            switch state {
+            case .ready: return .completeKeepAlive(true)
+            case .failed, .cancelled: return .complete(false)
+            default: return nil
+            }
+        }
+
+        if result {
+            // On keep-alive resolution, the helper must not have cancelled the
+            // connection itself. NWConnection.state is read off-actor and the
+            // value may lag, so accept anything other than .cancelled here —
+            // the contract we care about is "the helper did not call cancel".
+            switch connection.state {
+            case .cancelled:
+                Issue.record("connection was cancelled despite .completeKeepAlive")
+            default:
+                break
+            }
+            connection.cancel()
+        }
+    }
+
+    @Test("nil from classify ignores transient states")
+    func nilKeepsWaiting() async {
+        // UDP loopback transitions through .preparing (which the classifier
+        // ignores) before settling. The test verifies that returning nil for a
+        // state does not cause a premature resolve — i.e. we eventually reach
+        // .ready (or .failed) rather than the timeout fallback.
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host("127.0.0.1"),
+            port: NWEndpoint.Port(rawValue: 9)!
+        )
+        let connection = NWConnection(to: endpoint, using: .udp)
+
+        let result: String = await withNWConnection(
+            connection,
+            timeout: .seconds(2),
+            timeoutValue: "timeout"
+        ) { state in
+            switch state {
+            case .ready: return .complete("ready")
+            case .failed, .cancelled: return .complete("error")
+            default: return nil  // .setup, .preparing — keep waiting
+            }
+        }
+
+        #expect(result != "timeout", "should resolve via .ready or .failed, not timeout")
+    }
+}

--- a/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
+++ b/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
@@ -101,6 +101,10 @@ struct NetMonitorShortcutsTests {
     @Test("shortcuts provider includes all expected entries")
     func shortcutMembership() {
         let shortcuts = NetMonitorShortcuts.appShortcuts
-        #expect(shortcuts.count == 5)
+        #expect(shortcuts.contains { $0.intent is PingIntent })
+        #expect(shortcuts.contains { $0.intent is ScanNetworkIntent })
+        #expect(shortcuts.contains { $0.intent is SpeedTestIntent })
+        #expect(shortcuts.contains { $0.intent is NetworkStatusIntent })
+        #expect(shortcuts.contains { $0.intent is SaveWiFiReadingIntent })
     }
 }

--- a/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
+++ b/Tests/NetMonitor-iOSTests/AppIntentsTests.swift
@@ -101,10 +101,13 @@ struct NetMonitorShortcutsTests {
     @Test("shortcuts provider includes all expected entries")
     func shortcutMembership() {
         let shortcuts = NetMonitorShortcuts.appShortcuts
-        #expect(shortcuts.contains { $0.intent is PingIntent })
-        #expect(shortcuts.contains { $0.intent is ScanNetworkIntent })
-        #expect(shortcuts.contains { $0.intent is SpeedTestIntent })
-        #expect(shortcuts.contains { $0.intent is NetworkStatusIntent })
-        #expect(shortcuts.contains { $0.intent is SaveWiFiReadingIntent })
+        let shortcutIDs = NetMonitorShortcuts.shortcutIDs
+
+        #expect(shortcuts.count == shortcutIDs.count)
+        #expect(shortcutIDs.contains(.ping))
+        #expect(shortcutIDs.contains(.scanNetwork))
+        #expect(shortcutIDs.contains(.speedTest))
+        #expect(shortcutIDs.contains(.networkStatus))
+        #expect(shortcutIDs.contains(.saveWiFiReading))
     }
 }

--- a/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
@@ -443,4 +443,78 @@ struct DashboardViewModelEventLoggingTests {
         }
         #expect(!anchorEvents.isEmpty)
     }
+
+    @Test func measureAnchorsPingsConcurrently() async {
+        // Tracks in-flight ping calls so the test can verify parallel execution.
+        // Three anchors pinged sequentially would peak at 1 in-flight; parallel via
+        // TaskGroup peaks at 3.
+        let ping = ConcurrencyTrackingPingService(delay: .milliseconds(100))
+        let vm = makeVM(pingService: ping)
+
+        await vm.refresh()
+        await waitUntil { vm.anchorLatencies.count == 3 }
+
+        #expect(vm.anchorLatencies.count == 3)
+        #expect(ping.maxInFlight >= 2, "expected concurrent ping calls, got max=\(ping.maxInFlight)")
+    }
+
+    @Test func measureAnchorsRecordsAllSuccessfulAnchors() async {
+        let ping = ConcurrencyTrackingPingService(delay: .milliseconds(10))
+        let vm = makeVM(pingService: ping)
+
+        await vm.refresh()
+        await waitUntil { vm.anchorLatencies.count == 3 }
+
+        #expect(Set(vm.anchorLatencies.keys) == ["Google", "Cloudflare", "Apple"])
+        for value in vm.anchorLatencies.values {
+            #expect(value == 10.0)
+        }
+    }
+}
+
+// MARK: - Concurrency Tracking Mock
+
+/// Mock ping service that records the peak number of in-flight ping calls.
+/// Used to assert that `DashboardViewModel.measureAnchors` runs anchors in parallel
+/// rather than sequentially.
+final class ConcurrencyTrackingPingService: PingServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _inFlight = 0
+    private var _maxInFlight = 0
+    private let delay: Duration
+
+    init(delay: Duration = .milliseconds(50)) {
+        self.delay = delay
+    }
+
+    var maxInFlight: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _maxInFlight
+    }
+
+    func ping(host: String, count: Int, timeout: TimeInterval) async -> AsyncStream<PingResult> {
+        lock.lock()
+        _inFlight += 1
+        _maxInFlight = max(_maxInFlight, _inFlight)
+        lock.unlock()
+
+        try? await Task.sleep(for: delay)
+
+        lock.lock()
+        _inFlight -= 1
+        lock.unlock()
+
+        let result = PingResult(sequence: 1, host: host, ttl: 64, time: 10.0, isTimeout: false)
+        return AsyncStream { continuation in
+            continuation.yield(result)
+            continuation.finish()
+        }
+    }
+
+    func stop() async {}
+
+    func calculateStatistics(_ results: [PingResult], requestedCount: Int?) async -> PingStatistics? {
+        nil
+    }
 }

--- a/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/DashboardViewModelTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import os
 @testable import NetMonitor_iOS
 import NetMonitorCore
 import NetworkScanKit
@@ -477,10 +478,13 @@ struct DashboardViewModelEventLoggingTests {
 /// Mock ping service that records the peak number of in-flight ping calls.
 /// Used to assert that `DashboardViewModel.measureAnchors` runs anchors in parallel
 /// rather than sequentially.
-final class ConcurrencyTrackingPingService: PingServiceProtocol, @unchecked Sendable {
-    private let lock = NSLock()
-    private var _inFlight = 0
-    private var _maxInFlight = 0
+final class ConcurrencyTrackingPingService: PingServiceProtocol, Sendable {
+    private struct State {
+        var inFlight = 0
+        var maxInFlight = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
     private let delay: Duration
 
     init(delay: Duration = .milliseconds(50)) {
@@ -488,22 +492,18 @@ final class ConcurrencyTrackingPingService: PingServiceProtocol, @unchecked Send
     }
 
     var maxInFlight: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _maxInFlight
+        state.withLock { $0.maxInFlight }
     }
 
     func ping(host: String, count: Int, timeout: TimeInterval) async -> AsyncStream<PingResult> {
-        lock.lock()
-        _inFlight += 1
-        _maxInFlight = max(_maxInFlight, _inFlight)
-        lock.unlock()
+        state.withLock {
+            $0.inFlight += 1
+            $0.maxInFlight = max($0.maxInFlight, $0.inFlight)
+        }
 
         try? await Task.sleep(for: delay)
 
-        lock.lock()
-        _inFlight -= 1
-        lock.unlock()
+        state.withLock { $0.inFlight -= 1 }
 
         let result = PingResult(sequence: 1, host: host, ttl: 64, time: 10.0, isTimeout: false)
         return AsyncStream { continuation in

--- a/Tests/NetMonitor-iOSTests/LiquidGlassTests.swift
+++ b/Tests/NetMonitor-iOSTests/LiquidGlassTests.swift
@@ -32,13 +32,13 @@ struct LiquidGlassBackgroundModifierTests {
     /// The `.liquidGlassBackground(in:tint:)` modifier returns a view.
     @Test func shapeModifierReturnsView() {
         let modified = Text("hi").liquidGlassBackground(in: RoundedRectangle(cornerRadius: 8))
-        let _: AnyView = AnyView(modified)
+        _ = AnyView(modified)
     }
 
     /// The `.liquidGlassBackground(tint:)` modifier (default shape) returns a view.
     @Test func defaultShapeModifierReturnsView() {
         let modified = Text("hi").liquidGlassBackground()
-        let _: AnyView = AnyView(modified)
+        _ = AnyView(modified)
     }
 
     /// Tint parameter compiles for both overloads.

--- a/Tests/NetMonitor-iOSTests/SpeedTestToolViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/SpeedTestToolViewModelTests.swift
@@ -260,7 +260,8 @@ struct SpeedTestToolViewModelStartTestTests {
     }
 
     @Test func startTestReentrantGuardPreventsDoubleStart() async throws {
-        let (_, context) = try makeInMemoryStore()
+        let store = try makeInMemoryStore()
+        let context = store.1
         let mock = MockSpeedTestService()
         let vm = SpeedTestToolViewModel(service: mock)
 
@@ -273,10 +274,12 @@ struct SpeedTestToolViewModelStartTestTests {
         // Guard returned before `errorMessage = nil` — message unchanged
         #expect(vm.errorMessage == "keep this")
         #expect(vm.isRunning == true)
+        withExtendedLifetime(store.0) {}
     }
 
     @Test func startTestSuccessSyncsServiceState() async throws {
-        let (_, context) = try makeInMemoryStore()
+        let store = try makeInMemoryStore()
+        let context = store.1
         let mock = MockSpeedTestService()
         mock.downloadSpeed = 150
         mock.uploadSpeed = 60
@@ -295,6 +298,7 @@ struct SpeedTestToolViewModelStartTestTests {
         #expect(vm.latency == 18)
         #expect(vm.jitter == 3.5)
         #expect(vm.errorMessage == nil)
+        withExtendedLifetime(store.0) {}
     }
 
     @Test func completionFeedbackTokenOnlyExistsForCompletedRuns() {
@@ -318,7 +322,8 @@ struct SpeedTestToolViewModelStartTestTests {
     }
 
     @Test func startTestErrorSetsErrorMessage() async throws {
-        let (_, context) = try makeInMemoryStore()
+        let store = try makeInMemoryStore()
+        let context = store.1
         let mock = MockSpeedTestService()
         mock.shouldThrow = true
 
@@ -330,10 +335,12 @@ struct SpeedTestToolViewModelStartTestTests {
         #expect(vm.errorMessage != nil)
         #expect(vm.phase == .idle)
         #expect(vm.isRunning == false)
+        withExtendedLifetime(store.0) {}
     }
 
     @Test func startTestPersistsResultToModelContext() async throws {
-        let (_, context) = try makeInMemoryStore()
+        let store = try makeInMemoryStore()
+        let context = store.1
         let mock = MockSpeedTestService()
         mock.downloadSpeed = 200
         mock.uploadSpeed = 100
@@ -351,5 +358,6 @@ struct SpeedTestToolViewModelStartTestTests {
         #expect(results.count == 1)
         #expect(results.first?.downloadSpeed == 200)
         #expect(results.first?.uploadSpeed == 100)
+        withExtendedLifetime(store.0) {}
     }
 }

--- a/Tests/NetMonitor-iOSTests/SpeedTestToolViewModelTests.swift
+++ b/Tests/NetMonitor-iOSTests/SpeedTestToolViewModelTests.swift
@@ -211,6 +211,7 @@ struct SpeedTestToolViewModelErrorTests {
 
 // MARK: - Jitter, Persistence & startTest Tests
 
+@Suite(.serialized)
 @MainActor
 struct SpeedTestToolViewModelStartTestTests {
 
@@ -222,7 +223,11 @@ struct SpeedTestToolViewModelStartTestTests {
             SpeedTestResult.self,
             PairedMac.self
         ])
-        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let config = ModelConfiguration(
+            "SpeedTestToolViewModelTests-\(UUID().uuidString)",
+            schema: schema,
+            isStoredInMemoryOnly: true
+        )
         let container = try ModelContainer(for: schema, configurations: [config])
         return (container, container.mainContext)
     }

--- a/Tests/NetMonitor-macOSTests/PlatformServiceGapTests.swift
+++ b/Tests/NetMonitor-macOSTests/PlatformServiceGapTests.swift
@@ -233,6 +233,30 @@ struct CompanionServiceValueTypeTests {
     }
 }
 
+// MARK: - CompanionService Listener Queue Tests
+
+// Issue #221 — NWListener must run on a named, named-QoS dispatch queue,
+// not the shared .global() concurrent queue. A named queue gives thread
+// dumps clear attribution and prevents callbacks from competing with
+// arbitrary other .global() work at undefined QoS.
+
+struct CompanionServiceListenerQueueTests {
+
+    @Test("listener queue has the expected reverse-DNS label")
+    func listenerQueueLabel() async {
+        let service = CompanionService()
+        let queue = await service.listenerQueue
+        #expect(queue.label == "com.netmonitor.companion.listener")
+    }
+
+    @Test("listener queue QoS class is userInitiated")
+    func listenerQueueQoSIsUserInitiated() async {
+        let service = CompanionService()
+        let queue = await service.listenerQueue
+        #expect(queue.qos.qosClass == .userInitiated)
+    }
+}
+
 // MARK: - DefaultMonitorServiceProvider Tests
 
 struct DefaultMonitorServiceProviderTests {

--- a/Tests/NetMonitor-macOSTests/PlatformServiceGapTests.swift
+++ b/Tests/NetMonitor-macOSTests/PlatformServiceGapTests.swift
@@ -233,12 +233,13 @@ struct CompanionServiceValueTypeTests {
     }
 }
 
-// MARK: - CompanionService Listener Queue Tests
+// MARK: - CompanionService Callback Queue Tests
 
-// Issue #221 — NWListener must run on a named, named-QoS dispatch queue,
-// not the shared .global() concurrent queue. A named queue gives thread
-// dumps clear attribution and prevents callbacks from competing with
-// arbitrary other .global() work at undefined QoS.
+// Issue #221 — NWListener (and the accepted NWConnections it spawns) must
+// run on named, named-QoS dispatch queues, not the shared .global() concurrent
+// queue. A named queue gives thread dumps clear attribution and prevents
+// callbacks from competing with arbitrary other .global() work at undefined
+// QoS.
 
 struct CompanionServiceListenerQueueTests {
 
@@ -253,6 +254,20 @@ struct CompanionServiceListenerQueueTests {
     func listenerQueueQoSIsUserInitiated() async {
         let service = CompanionService()
         let queue = await service.listenerQueue
+        #expect(queue.qos.qosClass == .userInitiated)
+    }
+
+    @Test("connection queue has the expected reverse-DNS label")
+    func connectionQueueLabel() async {
+        let service = CompanionService()
+        let queue = await service.connectionQueue
+        #expect(queue.label == "com.netmonitor.companion.connection")
+    }
+
+    @Test("connection queue QoS class is userInitiated")
+    func connectionQueueQoSIsUserInitiated() async {
+        let service = CompanionService()
+        let queue = await service.connectionQueue
         #expect(queue.qos.qosClass == .userInitiated)
     }
 }

--- a/Tests/NetMonitor-macOSUITests/MacOSToolOutcomeUITests.swift
+++ b/Tests/NetMonitor-macOSUITests/MacOSToolOutcomeUITests.swift
@@ -470,7 +470,6 @@ final class MacOSToolOutcomeUITests: MacOSUITestCase {
 
         // Verify the Bonjour results area has content structure
         let hasContentStructure = waitForEither([
-            app.lists.firstMatch,
             app.tables.firstMatch,
             app.staticTexts.matching(
                 NSPredicate(format: "identifier BEGINSWITH 'bonjour_row_'")

--- a/Tests/NetMonitor-macOSUITests/TimelineUITests.swift
+++ b/Tests/NetMonitor-macOSUITests/TimelineUITests.swift
@@ -15,7 +15,7 @@ final class TimelineUITests: MacOSUITestCase {
         // Verify timeline has event content or empty state — not just a blank container
         let hasContent = waitForEither([
             app.tables["timeline_table_events"],
-            app.lists["timeline_list_events"],
+            app.descendants(matching: .any)["timeline_list_events"],
             app.staticTexts.matching(
                 NSPredicate(format: "identifier BEGINSWITH 'timeline_event_'")
             ).firstMatch,

--- a/project.yml
+++ b/project.yml
@@ -32,7 +32,7 @@ targets:
         CFBundleName: NetMonitor Pro
         CFBundleDisplayName: NetMonitor Pro
         CFBundleShortVersionString: "2.2.1"
-        CFBundleVersion: "1776881719"
+        CFBundleVersion: "1779160181"
         LSMinimumSystemVersion: "15.0"
         NSPrincipalClass: NSApplication
         NSHighResolutionCapable: true
@@ -148,7 +148,7 @@ targets:
         CFBundleName: Netmonitor
         CFBundleDisplayName: Netmonitor
         CFBundleShortVersionString: "2.2.1"
-        CFBundleVersion: "9"
+        CFBundleVersion: "10"
         CFBundleIconName: AppIcon
         NSCameraUsageDescription: "NetMonitor uses the camera for AR-assisted room scanning to create floor plans for Wi-Fi coverage surveys."
         NSLocationWhenInUseUsageDescription: "NetMonitor uses your location to display WiFi network information and monitor GeoFence zones."

--- a/project.yml
+++ b/project.yml
@@ -255,6 +255,41 @@ targets:
     dependencies:
       - package: NetMonitorCore
       - package: NetworkScanKit
+      - target: NetMonitorWidgetExtension
+        embed: true
+
+  NetMonitorWidgetExtension:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "18.0"
+    sources:
+      - path: NetMonitor-iOS/Widget
+      - path: NetMonitor-iOS/Platform/AppSettings.swift
+    entitlements:
+      path: NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.com.blakemiller.netmonitor
+    info:
+      path: NetMonitor-iOS/Widget/Info.plist
+      properties:
+        CFBundleDisplayName: Netmonitor Widget
+        CFBundleShortVersionString: "2.2.1"
+        CFBundleVersion: "10"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+        NSSupportsLiveActivities: true
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.blakemiller.netmonitor.widget
+        DEVELOPMENT_TEAM: 32XZRDTGK3
+        SWIFT_VERSION: 6.0
+        SWIFT_STRICT_CONCURRENCY: complete
+        CODE_SIGN_STYLE: Automatic
+        IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+        CODE_SIGN_ENTITLEMENTS: NetMonitor-iOS/Widget/NetMonitorWidgetExtension.entitlements
+    dependencies:
+      - package: NetMonitorCore
 
   NetMonitor-macOSTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? Link the beads issue: bd show <id> -->

Closes: <!-- NetMonitor-2.0-xyz -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Testing Done

- [ ] Unit tests pass (`xcodebuild test -scheme NetMonitor-macOS` on mac-mini)
- [ ] iOS tests pass (`xcodebuild test -scheme NetMonitor-iOS` on mac-mini)
- [ ] SwiftLint clean — no new errors (`swiftlint lint --quiet`)
- [ ] SwiftFormat clean — no reformats needed (`swiftformat --lint .`)
- [ ] Manual verification on device / simulator

## Notes for Reviewer

<!-- Anything non-obvious, trade-offs made, follow-up beads issues filed -->
