### PR TITLE
feat: NetMonitor v2.2.1 reliability and responsiveness

### DIFF
--- a/NetMonitor-2.0.xcodeproj/project.pbxproj
+++ b/NetMonitor-2.0.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		02F1D11D8040B5ABE82A311B /* GatewayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ECEB0143FB17F5EE8C4EB4 /* GatewayService.swift */; };
 		0339F8A0415336098C06AF55 /* ConnectionSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA713685A5D01F84A2D34A6 /* ConnectionSettingsSection.swift */; };
 		03B3955D9B9092EBB8326001 /* GeoTraceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A442A04A1D5C91B75152740 /* GeoTraceViewModel.swift */; };
+		03D97B1C71BFEB7A4C2496A1 /* PersistenceRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7B23E2D815B42A8B331ADA /* PersistenceRecoveryView.swift */; };
 		040D7C9436AF7952FF0DF1B8 /* DeviceNameResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D152B7122837F9AC51842F34 /* DeviceNameResolver.swift */; };
 		05C4FB91A5C6380CCA566F1C /* LiveActivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6B545F58A386B0F4482FF2 /* LiveActivityUITests.swift */; };
 		0628D7C64272D6E64FDE9378 /* DeviceDiscoveryCoordinatorErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01149AB97A44B19B28D5A95C /* DeviceDiscoveryCoordinatorErrorTests.swift */; };
@@ -249,6 +250,7 @@
 		86BABB12476B7BDFBBFBCF1D /* LiveActivityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C420F52BE76942C60D4925B /* LiveActivityManagerTests.swift */; };
 		87073AF5E1F7C32B62C3286E /* BonjourDiscoveryToolViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BC316F3DB96C6B180E0814 /* BonjourDiscoveryToolViewModel.swift */; };
 		8799A697534134CF042C4848 /* DataMaintenanceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3040499F7A80AFDBC284E188 /* DataMaintenanceServiceTests.swift */; };
+		87DB0F0965199B4BB3E25411 /* PersistenceRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA7544FC741B6E9B70E195F /* PersistenceRecoveryView.swift */; };
 		87F8C04AE709A8337D320FCB /* UptimeHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02F9A3B9E5936A4B1BD948D /* UptimeHistoryView.swift */; };
 		88972A34C3E66281CF1A0CD3 /* SSLCertificateMonitorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D1CAE1F08AF8C7C2450636 /* SSLCertificateMonitorUITests.swift */; };
 		88CA4E319D8AC8D6C5F4F83A /* MacTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF0C346E28EDB80D9A26AB /* MacTheme.swift */; };
@@ -818,6 +820,7 @@
 		AD6EC88007BD40A5D73D72C1 /* ShellCommandRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellCommandRunnerTests.swift; sourceTree = "<group>"; };
 		ADE8B26F50AFCAD208AC99F0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AE584A8394FFA0BFC9255154 /* NetworkEventServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEventServiceTests.swift; sourceTree = "<group>"; };
+		AEA7544FC741B6E9B70E195F /* PersistenceRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRecoveryView.swift; sourceTree = "<group>"; };
 		AEF5692D7F6FBF3F5506C69E /* NetMonitor-iOSUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "NetMonitor-iOSUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0AFB80A0447C601E26B6416 /* WiFiBandVersionCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiBandVersionCompatTests.swift; sourceTree = "<group>"; };
 		B0BC4A7335A7D1D27798D9F3 /* PortScannerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerServiceTests.swift; sourceTree = "<group>"; };
@@ -839,6 +842,7 @@
 		BC50DF5BC553FC2B2E1E51FA /* ISPLookupServiceCacheErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISPLookupServiceCacheErrorTests.swift; sourceTree = "<group>"; };
 		BC9B8228A5B2FFCD294C88EC /* ToolsGoldenPathUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsGoldenPathUITests.swift; sourceTree = "<group>"; };
 		BCD97CE135CA42D41D9F1A8F /* WorldPingToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldPingToolView.swift; sourceTree = "<group>"; };
+		BD7B23E2D815B42A8B331ADA /* PersistenceRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRecoveryView.swift; sourceTree = "<group>"; };
 		BDDA6904D162A74575EE323F /* BlueprintBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintBuilder.swift; sourceTree = "<group>"; };
 		BE1FDACEF3393A09F365EEB4 /* PortScannerToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerToolView.swift; sourceTree = "<group>"; };
 		BF43C912ACE0DEB478B1BD11 /* DeviceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRowView.swift; sourceTree = "<group>"; };
@@ -1223,6 +1227,7 @@
 				D33FA8CEF889C0CD95DE23EF /* GlassButton.swift */,
 				4242598E5085508175C23443 /* LabelValueRow.swift */,
 				2C3943143B99D5243073376A /* MetricCard.swift */,
+				AEA7544FC741B6E9B70E195F /* PersistenceRecoveryView.swift */,
 				EE0A10C8D0A4922F6690C62B /* StatusBadge.swift */,
 				6EBC131061CB2EF8420343A0 /* ToolClearButton.swift */,
 				28840E366E12B65E3AAD7F2E /* ToolInputField.swift */,
@@ -1826,6 +1831,7 @@
 				8F7663D6B71E58A8F1302100 /* FlowLayout.swift */,
 				FA1FE76E2FDC78460F33EE00 /* LabelValueRow.swift */,
 				5EA84BE258FB44E79A514C66 /* MiniSparklineView.swift */,
+				BD7B23E2D815B42A8B331ADA /* PersistenceRecoveryView.swift */,
 				30C5FE8DF81C4531CE1DFD8C /* QuickJumpSheet.swift */,
 			);
 			path = Components;
@@ -2030,13 +2036,13 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				B151786BC5800BC9BC47A22C /* NetMonitor-iOS */,
-				BA9349CB56A8E5516B5F9B7C /* NetMonitor-iOSTests */,
-				5CB1A3281BD96170A689A274 /* NetMonitor-iOSUITests */,
 				1F7C65C74B339FCF977C4759 /* NetMonitor-macOS */,
-				55DBFE8BA4B4B55A24D71850 /* NetMonitor-macOSTests */,
-				A433A8E38101EED718D3EF55 /* NetMonitor-macOSUITests */,
+				B151786BC5800BC9BC47A22C /* NetMonitor-iOS */,
 				46136558EDB186C25492B378 /* NetMonitorWidgetExtension */,
+				55DBFE8BA4B4B55A24D71850 /* NetMonitor-macOSTests */,
+				BA9349CB56A8E5516B5F9B7C /* NetMonitor-iOSTests */,
+				A433A8E38101EED718D3EF55 /* NetMonitor-macOSUITests */,
+				5CB1A3281BD96170A689A274 /* NetMonitor-iOSUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -2180,6 +2186,7 @@
 				FDE87C90F67B833E55AB9E3E /* NetworkSettingsView.swift in Sources */,
 				C4C5ACBD522211FA0699B3BB /* NoOpSpeedTestService.swift in Sources */,
 				0AC79B50B27FC4E46F840E0A /* NotificationSettingsView.swift in Sources */,
+				03D97B1C71BFEB7A4C2496A1 /* PersistenceRecoveryView.swift in Sources */,
 				E335213C27FEB11C10DE25F2 /* PingToolView.swift in Sources */,
 				B90A3DA2C8AC570A246AC885 /* PortScannerToolView.swift in Sources */,
 				40F4B26744E22BB9A735228A /* PreviewContainer.swift in Sources */,
@@ -2362,6 +2369,7 @@
 				30774D035C15A54E9E45E050 /* NetworkStatusIntent.swift in Sources */,
 				C27D1C5E68E88D4354AA53DC /* OnboardingView.swift in Sources */,
 				94736D3A87E0BEFA4670767F /* PDFReportGenerator.swift in Sources */,
+				87DB0F0965199B4BB3E25411 /* PersistenceRecoveryView.swift in Sources */,
 				78D18A801FB2DE49FD86FDE9 /* PingIntent.swift in Sources */,
 				4C606703D8CFF77BAB7C6C3A /* PingToolView.swift in Sources */,
 				75D12772A3AB65312C865EA3 /* PingToolViewModel.swift in Sources */,

--- a/NetMonitor-iOS/App/NetmonitorApp.swift
+++ b/NetMonitor-iOS/App/NetmonitorApp.swift
@@ -28,7 +28,7 @@ struct NetmonitorApp: App {
         return false
     }
 
-    var sharedModelContainer: ModelContainer = {
+    private static let persistenceOutcome: PersistenceBootstrapOutcome<ModelContainer> = {
         let schema = Schema([
             PairedMac.self,
             LocalDevice.self,
@@ -43,11 +43,26 @@ struct NetmonitorApp: App {
         )
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            return try PersistenceBootstrap.load(
+                persistentStore: {
+                    try ModelContainer(for: schema, configurations: [modelConfiguration])
+                },
+                fallbackStore: {
+                    let fallback = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+                    return try ModelContainer(for: schema, configurations: [fallback])
+                }
+            )
         } catch {
-            fatalError("Could not create ModelContainer: \(error)")
+            fatalError("Could not create recovery ModelContainer: \(error)")
         }
     }()
+
+    private var sharedModelContainer: ModelContainer { Self.persistenceOutcome.store }
+
+    init() {
+        guard !Self.isUITesting else { return }
+        BackgroundTaskService.shared.registerTasks()
+    }
 
     // Respect user's appearance preference (light/dark/system)
     private var resolvedColorScheme: ColorScheme? {
@@ -60,7 +75,13 @@ struct NetmonitorApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(env: environment)
+            Group {
+                if let recovery = Self.persistenceOutcome.recovery {
+                    PersistenceRecoveryView(recovery: recovery)
+                } else {
+                    ContentView(env: environment)
+                }
+            }
                 .preferredColorScheme(resolvedColorScheme)
                 .accessibilityIdentifier("screen_main")
                 .environment(environment)
@@ -74,7 +95,7 @@ struct NetmonitorApp: App {
                 .onAppear {
                     UITestBootstrap.configureIfNeeded()
 
-                    if Self.isUITesting {
+                    if Self.isUITesting || Self.persistenceOutcome.isDegraded {
                         return
                     }
 
@@ -93,7 +114,6 @@ struct NetmonitorApp: App {
                     // Start event listener to log connectivity/device changes for Timeline.
                     EventListenerService.shared.start()
 
-                    BackgroundTaskService.shared.registerTasks()
                     BackgroundTaskService.shared.scheduleRefreshTask()
                     BackgroundTaskService.shared.scheduleSyncTask()
 

--- a/NetMonitor-iOS/Platform/BackgroundTaskService.swift
+++ b/NetMonitor-iOS/Platform/BackgroundTaskService.swift
@@ -10,6 +10,8 @@ import os
 /// Manages background task scheduling for periodic network checks
 @MainActor
 final class BackgroundTaskService {
+    typealias TaskRegistration = (String, DispatchQueue?, @escaping (BGTask) -> Void) -> Bool
+
     static let shared = BackgroundTaskService()
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.blakemiller.netmonitor", category: "BackgroundTaskService")
 
@@ -17,14 +19,31 @@ final class BackgroundTaskService {
     static let syncTaskIdentifier = "com.blakemiller.netmonitor.sync"
     static let scheduledNetworkScanTaskIdentifier = "com.blakemiller.netmonitor.scheduledNetworkScan"
 
-    private init() {}
+    private let registerTask: TaskRegistration
+    private var hasRegisteredTasks = false
+
+    init(registerTask: @escaping TaskRegistration = { identifier, queue, launchHandler in
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: identifier,
+            using: queue,
+            launchHandler: launchHandler
+        )
+    }) {
+        self.registerTask = registerTask
+    }
 
     // MARK: - Registration
 
     func registerTasks() {
+        guard !hasRegisteredTasks else {
+            Self.logger.debug("Background tasks already registered; skipping duplicate request")
+            return
+        }
+        hasRegisteredTasks = true
+
         Self.logger.info("Registering background tasks...")
 
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.refreshTaskIdentifier, using: .main) { task in
+        _ = registerTask(Self.refreshTaskIdentifier, .main) { task in
             guard let refreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)
                 return
@@ -35,7 +54,7 @@ final class BackgroundTaskService {
         }
         Self.logger.debug("✅ Registered: \(Self.refreshTaskIdentifier)")
 
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.syncTaskIdentifier, using: .main) { task in
+        _ = registerTask(Self.syncTaskIdentifier, .main) { task in
             guard let syncTask = task as? BGProcessingTask else {
                 task.setTaskCompleted(success: false)
                 return
@@ -46,7 +65,7 @@ final class BackgroundTaskService {
         }
         Self.logger.debug("✅ Registered: \(Self.syncTaskIdentifier)")
 
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.scheduledNetworkScanTaskIdentifier, using: .main) { task in
+        _ = registerTask(Self.scheduledNetworkScanTaskIdentifier, .main) { task in
             guard let scanTask = task as? BGProcessingTask else {
                 task.setTaskCompleted(success: false)
                 return
@@ -448,6 +467,7 @@ final class BackgroundTaskService {
             Self.logger.warning("⏰ Network scan task expiration handler called")
             Task { @MainActor in
                 taskCancelled = true
+                DeviceDiscoveryService.shared.stopScan()
                 complete(false)
             }
         }

--- a/NetMonitor-iOS/Platform/EventListenerService.swift
+++ b/NetMonitor-iOS/Platform/EventListenerService.swift
@@ -1,5 +1,53 @@
 import Foundation
 import NetMonitorCore
+import os
+
+// MARK: - ObservationChangeWaiter
+
+/// Bridges Observation's callback API into async code without leaving a
+/// continuation suspended when its task is cancelled.
+final class ObservationChangeWaiter: @unchecked Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<Void, Never>?
+        var isResolved = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    @MainActor
+    func wait(_ registerObservation: (@escaping @Sendable () -> Void) -> Void) async {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let shouldResumeImmediately = state.withLock { state in
+                    guard !state.isResolved else { return true }
+                    state.continuation = continuation
+                    return false
+                }
+
+                guard !shouldResumeImmediately else {
+                    continuation.resume()
+                    return
+                }
+
+                registerObservation { [weak self] in
+                    self?.resume()
+                }
+            }
+        } onCancel: {
+            resume()
+        }
+    }
+
+    private func resume() {
+        let continuation = state.withLock { state -> CheckedContinuation<Void, Never>? in
+            guard !state.isResolved else { return nil }
+            state.isResolved = true
+            defer { state.continuation = nil }
+            return state.continuation
+        }
+        continuation?.resume()
+    }
+}
 
 // MARK: - EventListenerService
 
@@ -44,17 +92,18 @@ final class EventListenerService {
         monitorTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                // Suspend until any tracked @Observable property changes
-                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                let waiter = ObservationChangeWaiter()
+                await waiter.wait { onChange in
                     withObservationTracking {
                         _ = self.networkMonitor.isConnected
                         _ = self.networkMonitor.connectionType
                         _ = self.discoveryService.isScanning
                         _ = self.discoveryService.discoveredDevices
                     } onChange: {
-                        continuation.resume()
+                        onChange()
                     }
                 }
+                guard !Task.isCancelled else { return }
                 self.handleConnectivityChange()
                 self.handleScanChange()
             }

--- a/NetMonitor-iOS/Platform/MacConnectionService.swift
+++ b/NetMonitor-iOS/Platform/MacConnectionService.swift
@@ -47,19 +47,20 @@ final class MacConnectionService: MacConnectionServiceProtocol {
     private let queue = DispatchQueue(label: "com.netmonitor.macconnection", qos: .userInitiated)
     private var heartbeatTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
-    private var receiveBuffer = Data()
+    private var frameDecoder = CompanionFrameDecoder()
+    private var connectionGeneration = UUID()
     private var pendingEndpoint: NWEndpoint?
     private var pendingMacName: String?
     private var lastConnectedEndpoint: NWEndpoint?
     private var lastConnectedMacName: String?
     private var shouldAutoReconnect = false
+    private var reconnectAttempt = 0
     private let networkProfileManager: NetworkProfileManager
 
     // MARK: - Constants
 
     private static let serviceType = "_netmon._tcp"
     private static let heartbeatInterval: TimeInterval = 15
-    private static let reconnectDelay: TimeInterval = 5
     private static let heartbeatVersion = "1.0"
 
     private init(networkProfileManager: NetworkProfileManager = NetworkProfileManager()) {
@@ -173,7 +174,9 @@ final class MacConnectionService: MacConnectionServiceProtocol {
     }
 
     func disconnect() {
+        connectionGeneration = UUID()
         shouldAutoReconnect = false
+        reconnectAttempt = 0
         heartbeatTask?.cancel()
         heartbeatTask = nil
         reconnectTask?.cancel()
@@ -182,53 +185,64 @@ final class MacConnectionService: MacConnectionServiceProtocol {
         connection = nil
         connectionState = .disconnected
         connectedMacName = nil
-        receiveBuffer = Data()
+        frameDecoder = CompanionFrameDecoder()
         lastStatusUpdate = nil
         lastTargetList = nil
         lastDeviceList = nil
     }
 
     private func setupConnection(_ conn: NWConnection, macName: String) {
+        let generation = UUID()
+        connectionGeneration = generation
         connection = conn
 
         conn.stateUpdateHandler = { [weak self] state in
             Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.handleConnectionState(state, macName: macName)
+                guard let self, self.connectionGeneration == generation else { return }
+                self.handleConnectionState(state, connection: conn, macName: macName, generation: generation)
             }
         }
 
         conn.start(queue: queue)
     }
 
-    private func handleConnectionState(_ state: NWConnection.State, macName: String) {
+    private func handleConnectionState(
+        _ state: NWConnection.State,
+        connection: NWConnection,
+        macName: String,
+        generation: UUID
+    ) {
         switch state {
         case .ready:
+            reconnectAttempt = 0
             connectionState = .connected
             connectedMacName = macName
             lastConnectedEndpoint = pendingEndpoint
             lastConnectedMacName = pendingMacName
-            receiveBuffer = Data()
+            frameDecoder = CompanionFrameDecoder()
             // Delay slightly to let UI settle before starting I/O
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, self.connectionGeneration == generation else { return }
                 try? await Task.sleep(for: .milliseconds(100))
+                guard self.connectionGeneration == generation else { return }
                 self.startHeartbeat()
-                self.scheduleReceive()
+                self.scheduleReceive(connection: connection, generation: generation)
                 await self.sendLocalNetworkProfile()
             }
 
         case .failed(let error):
+            self.connection = nil
             connectionState = .error(error.localizedDescription)
             connectedMacName = nil
             heartbeatTask?.cancel()
             heartbeatTask = nil
-            scheduleReconnect()
+            scheduleReconnect(generation: generation)
 
         case .cancelled:
             if shouldAutoReconnect {
+                self.connection = nil
                 connectionState = .disconnected
-                scheduleReconnect()
+                scheduleReconnect(generation: generation)
             }
 
         case .waiting(let error):
@@ -268,68 +282,54 @@ final class MacConnectionService: MacConnectionServiceProtocol {
 
     // MARK: - Receive
 
-    private func scheduleReceive() {
-        guard let conn = connection else { return }
-
-        conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-
-                if let data = content, !data.isEmpty {
-                    self.receiveBuffer.append(data)
-                    self.processReceiveBuffer()
+    private func scheduleReceive(connection: NWConnection, generation: UUID) {
+        let decoder = frameDecoder
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
+            Task { [weak self] in
+                let batch: CompanionFrameBatch
+                if let content, !content.isEmpty {
+                    batch = await decoder.append(content)
+                } else {
+                    batch = CompanionFrameBatch(messages: [], errors: [])
                 }
 
-                if isComplete || error != nil {
-                    // Connection ended
-                    return
-                }
+                await MainActor.run {
+                    guard let self, self.connectionGeneration == generation else { return }
+                    for message in batch.messages {
+                        self.handleMessage(message)
+                    }
+                    if !batch.errors.isEmpty {
+                        Self.logger.error("Rejected \(batch.errors.count) companion frame(s)")
+                    }
 
-                self.scheduleReceive()
+                    if isComplete || error != nil {
+                        self.handleReceiveTermination(error: error, generation: generation)
+                    } else {
+                        self.scheduleReceive(connection: connection, generation: generation)
+                    }
+                }
             }
         }
     }
 
-    private func processReceiveBuffer() {
-        // Process all complete frames in the buffer
-        while receiveBuffer.count >= 4 {
-            // Read 4 bytes explicitly to avoid UnsafeRawBufferPointer slice issues
-            let b0 = receiveBuffer[receiveBuffer.startIndex]
-            let b1 = receiveBuffer[receiveBuffer.startIndex + 1]
-            let b2 = receiveBuffer[receiveBuffer.startIndex + 2]
-            let b3 = receiveBuffer[receiveBuffer.startIndex + 3]
-            let length = UInt32(b0) << 24 | UInt32(b1) << 16 | UInt32(b2) << 8 | UInt32(b3)
-
-            // Sanity check — reject absurdly large frames (max 10 MB)
-            guard length > 0, length <= 10_000_000 else {
-                Self.logger.error("Invalid frame length \(length), clearing buffer")
-                receiveBuffer.removeAll()
-                break
-            }
-
-            let totalFrameSize = 4 + Int(length)
-            guard receiveBuffer.count >= totalFrameSize else {
-                // Need more data
-                break
-            }
-
-            let startIndex = receiveBuffer.startIndex
-            let payloadStartIndex = startIndex + 4
-            let payloadEndIndex = startIndex + totalFrameSize
-            let jsonData = receiveBuffer.subdata(in: payloadStartIndex..<payloadEndIndex)
-            receiveBuffer.removeSubrange(startIndex..<payloadEndIndex)
-
-            do {
-                let message = try CompanionMessage.decode(from: jsonData)
-                handleMessage(message)
-            } catch {
-                Self.logger.error("Decode error: \(error)")
-            }
+    private func handleReceiveTermination(error: NWError?, generation: UUID) {
+        guard connectionGeneration == generation else { return }
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        connection = nil
+        connectedMacName = nil
+        if let error {
+            connectionState = .error(error.localizedDescription)
+        } else {
+            connectionState = .disconnected
+        }
+        if shouldAutoReconnect {
+            scheduleReconnect(generation: generation)
         }
     }
 
     private func handleMessage(_ message: CompanionMessage) {
-        Self.logger.info("handleMessage: received \(String(describing: message))")
+        Self.logger.debug("Received companion message: \(message.logName, privacy: .public)")
         switch message {
         case .statusUpdate(let payload):
             lastStatusUpdate = payload
@@ -338,7 +338,7 @@ final class MacConnectionService: MacConnectionServiceProtocol {
         case .deviceList(let payload):
             lastDeviceList = payload
         case .networkProfile(let payload):
-            Self.logger.info("Received network profile from Mac: \(payload.name)")
+            Self.logger.info("Received network profile from Mac")
             let companionName = payload.sourceDeviceName.map { "\($0) Network" } ?? payload.name
             if networkProfileManager.upsertCompanionProfile(
                 gateway: payload.gatewayIP,
@@ -352,7 +352,7 @@ final class MacConnectionService: MacConnectionServiceProtocol {
         case .toolResult(let payload):
             Self.logger.info("Tool result: \(payload.tool) - \(payload.success)")
         case .error(let payload):
-            Self.logger.error("Error from Mac: \(payload.message)")
+            Self.logger.error("Error from Mac: code=\(payload.code, privacy: .public)")
         case .heartbeat:
             Self.logger.debug("Heartbeat received")
         case .command:
@@ -363,9 +363,11 @@ final class MacConnectionService: MacConnectionServiceProtocol {
 
     // MARK: - Testing Support
 
-    func processIncomingDataForTesting(_ data: Data) {
-        receiveBuffer.append(data)
-        processReceiveBuffer()
+    func processIncomingDataForTesting(_ data: Data) async {
+        let batch = await frameDecoder.append(data)
+        for message in batch.messages {
+            handleMessage(message)
+        }
     }
 
     private func sendLocalNetworkProfile() async {
@@ -408,23 +410,51 @@ final class MacConnectionService: MacConnectionServiceProtocol {
 
     // MARK: - Reconnect
 
-    private func scheduleReconnect() {
-        guard shouldAutoReconnect, let endpoint = lastConnectedEndpoint else { return }
+    static func reconnectDelay(attempt: Int, jitterFraction: Double) -> TimeInterval {
+        let exponent = Double(max(attempt - 1, 0))
+        let base = min(60, pow(2, exponent))
+        let jitter = base * 0.25 * min(max(jitterFraction, 0), 1)
+        return min(60, base + jitter)
+    }
 
-        reconnectTask?.cancel()
+    private func scheduleReconnect(generation: UUID) {
+        guard shouldAutoReconnect,
+              connectionGeneration == generation,
+              reconnectTask == nil,
+              let endpoint = lastConnectedEndpoint ?? pendingEndpoint else { return }
+
+        reconnectAttempt += 1
+        let delay = Self.reconnectDelay(attempt: reconnectAttempt, jitterFraction: Double.random(in: 0...1))
         reconnectTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(Self.reconnectDelay))
+            try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             guard let self else { return }
 
             await MainActor.run {
-                guard self.shouldAutoReconnect else { return }
+                self.reconnectTask = nil
+                guard self.shouldAutoReconnect,
+                      self.connectionGeneration == generation else { return }
                 self.connectionState = .connecting
 
                 let parameters = NWParameters.tcp
                 let conn = NWConnection(to: endpoint, using: parameters)
                 self.setupConnection(conn, macName: self.lastConnectedMacName ?? "Mac")
             }
+        }
+    }
+}
+
+private extension CompanionMessage {
+    var logName: String {
+        switch self {
+        case .statusUpdate: "statusUpdate"
+        case .targetList: "targetList"
+        case .deviceList: "deviceList"
+        case .networkProfile: "networkProfile"
+        case .command: "command"
+        case .toolResult: "toolResult"
+        case .error: "error"
+        case .heartbeat: "heartbeat"
         }
     }
 }

--- a/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
+++ b/NetMonitor-iOS/ViewModels/DashboardViewModel.swift
@@ -158,6 +158,14 @@ final class DashboardViewModel {
         deviceDiscoveryService.isScanning
     }
 
+    var scanProgress: Double {
+        deviceDiscoveryService.scanProgress
+    }
+
+    var scanPhase: ScanDisplayPhase {
+        deviceDiscoveryService.scanPhase
+    }
+
     var sessionDuration: String {
         let interval = Date().timeIntervalSince(sessionStartTime)
         let hours = Int(interval) / 3600
@@ -181,8 +189,12 @@ final class DashboardViewModel {
         if let wifi = wifiService.currentWiFi, wifi.ssid != lastLoggedWiFiSSID {
             lastLoggedWiFiSSID = wifi.ssid
             var parts: [String] = []
-            if let signal = wifi.signalStrength { parts.append("\(signal)% signal") }
-            if let sec = wifi.securityType { parts.append(sec) }
+            if let signal = wifi.signalStrength {
+                parts.append("\(signal)% signal")
+            }
+            if let sec = wifi.securityType {
+                parts.append(sec)
+            }
             activityLog.add(
                 tool: "WiFi",
                 target: wifi.ssid,

--- a/NetMonitor-iOS/Views/Components/PersistenceRecoveryView.swift
+++ b/NetMonitor-iOS/Views/Components/PersistenceRecoveryView.swift
@@ -1,0 +1,27 @@
+import NetMonitorCore
+import SwiftUI
+
+struct PersistenceRecoveryView: View {
+    let recovery: PersistenceRecoveryState
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(recovery.title, systemImage: "externaldrive.badge.exclamationmark")
+        } description: {
+            Text(recovery.message)
+        } actions: {
+            ShareLink(item: recovery.diagnosticText) {
+                Label("Share Diagnostics", systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("persistenceRecovery_button_shareDiagnostics")
+
+            Text("Fully quit and reopen NetMonitor to retry. If this screen returns, share the diagnostics before reinstalling.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .accessibilityIdentifier("persistenceRecovery_screen")
+    }
+}

--- a/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
+++ b/NetMonitor-iOS/Views/Dashboard/DashboardView.swift
@@ -262,16 +262,26 @@ struct TacticalHUDHeader: View {
     }
 
     func signalColor(_ strength: Int) -> Color {
-        if strength > 70 { return Theme.Colors.success }
-        if strength > 40 { return Theme.Colors.warning }
+        if strength > 70 {
+            return Theme.Colors.success
+        }
+        if strength > 40 {
+            return Theme.Colors.warning
+        }
         return Theme.Colors.error
     }
 
     var wifiIconName: String {
         guard let dbm = viewModel.currentWiFi?.signalDBm else { return "wifi" }
-        if dbm > -50 { return "wifi" }
-        if dbm > -60 { return "wifi" }
-        if dbm > -70 { return "wifi" }
+        if dbm > -50 {
+            return "wifi"
+        }
+        if dbm > -60 {
+            return "wifi"
+        }
+        if dbm > -70 {
+            return "wifi"
+        }
         return "wifi"
     }
 }
@@ -282,20 +292,34 @@ struct RefinedNetworkHealthCard: View {
     let viewModel: DashboardViewModel
 
     var healthScore: Int {
-        if !viewModel.isConnected { return 0 }
+        if !viewModel.isConnected {
+            return 0
+        }
 
         var score = 100
 
         // Factor 1: Gateway latency (0-50 points)
         if let latency = viewModel.gateway?.latency {
-            if latency > 100 { score -= 50 } else if latency > 50 { score -= 30 } else if latency > 20 { score -= 10 }
+            if latency > 100 {
+                score -= 50
+            } else if latency > 50 {
+                score -= 30
+            } else if latency > 20 {
+                score -= 10
+            }
         } else {
             score -= 30 // No gateway response
         }
 
         // Factor 2: WiFi signal (0-30 points)
         if let signal = viewModel.currentWiFi?.signalStrength {
-            if signal < 30 { score -= 30 } else if signal < 50 { score -= 20 } else if signal < 70 { score -= 10 }
+            if signal < 30 {
+                score -= 30
+            } else if signal < 50 {
+                score -= 20
+            } else if signal < 70 {
+                score -= 10
+            }
         }
 
         // Factor 3: Jitter (0-20 points) — variance in recent latency
@@ -304,7 +328,11 @@ struct RefinedNetworkHealthCard: View {
             let avg = history.reduce(0, +) / Double(history.count)
             let variance = history.map { ($0 - avg) * ($0 - avg) }.reduce(0, +) / Double(history.count)
             let stddev = variance.squareRoot()
-            if stddev > 20 { score -= 20 } else if stddev > 10 { score -= 10 }
+            if stddev > 20 {
+                score -= 20
+            } else if stddev > 10 {
+                score -= 10
+            }
         }
 
         return max(0, min(100, score))
@@ -380,12 +408,16 @@ struct RefinedNetworkHealthCard: View {
     }
 
     private var healthStatusTitle: String {
-        if !viewModel.isConnected { return "Network Offline" }
+        if !viewModel.isConnected {
+            return "Network Offline"
+        }
         return healthScore > 80 ? "Optimal Performance" : "Degraded Signal"
     }
 
     private var healthDetailText: String {
-        if !viewModel.isConnected { return "Check your local connection" }
+        if !viewModel.isConnected {
+            return "Check your local connection"
+        }
         var parts: [String] = []
         parts.append("\(viewModel.deviceCount) devices active")
         if let latency = viewModel.gateway?.latency {
@@ -562,8 +594,12 @@ struct AnchorMetricColumn: View {
 
     private var dotColor: Color {
         guard let ms = latency else { return Theme.Colors.textTertiary }
-        if ms < 50 { return Theme.Colors.success }
-        if ms < 120 { return Theme.Colors.warning }
+        if ms < 50 {
+            return Theme.Colors.success
+        }
+        if ms < 120 {
+            return Theme.Colors.warning
+        }
         return .red
     }
 
@@ -675,18 +711,37 @@ struct LocalDevicesCard: View {
                     }
 
                     if viewModel.discoveredDevices.isEmpty {
-                        Text("SEARCHING FOR HARDWARE...")
-                            .font(.system(size: 10, weight: .black, design: .monospaced))
-                            .foregroundStyle(Theme.Colors.textTertiary)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.vertical, 10)
+                        HStack(spacing: 8) {
+                            if viewModel.isScanning {
+                                ProgressView(value: viewModel.scanProgress)
+                                    .progressViewStyle(.circular)
+                                    .controlSize(.small)
+                                Text("SCANNING • \(viewModel.scanPhase.rawValue.uppercased())")
+                            } else if !viewModel.isConnected {
+                                Image(systemName: "wifi.slash")
+                                Text("CONNECT TO WI-FI TO SCAN")
+                            } else if viewModel.lastScanDate != nil {
+                                Image(systemName: "arrow.clockwise")
+                                Text("NO DEVICES FOUND • SCAN AGAIN")
+                            } else {
+                                Image(systemName: "dot.radiowaves.left.and.right")
+                                Text("NO SCAN YET • RUN A DEVICE SCAN")
+                            }
+                        }
+                        .font(.system(size: 10, weight: .black, design: .monospaced))
+                        .foregroundStyle(Theme.Colors.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 10)
+                        .accessibilityIdentifier("dashboard_devices_emptyState")
                     }
                 }
             }
+            .accessibilityIdentifier("dashboard_card_localDevices")
         }
         .buttonStyle(PlainButtonStyle())
         .frame(maxHeight: sizeClass == .regular ? .infinity : nil)
-        .accessibilityIdentifier("dashboard_card_localDevices")
+        .accessibilityIdentifier("dashboard_link_devices")
+        .accessibilityValue("\(viewModel.deviceCount) devices")
     }
 }
 
@@ -737,7 +792,15 @@ struct DeviceRow: View {
 // MARK: - Speed Test Quick Card
 
 struct SpeedTestQuickCard: View {
-    @Query(sort: \SpeedTestResult.timestamp, order: .reverse) private var history: [SpeedTestResult]
+    private static var latestResultDescriptor: FetchDescriptor<SpeedTestResult> {
+        var descriptor = FetchDescriptor<SpeedTestResult>(
+            sortBy: [SortDescriptor(\SpeedTestResult.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        return descriptor
+    }
+
+    @Query(Self.latestResultDescriptor) private var history: [SpeedTestResult]
 
     private var lastResult: SpeedTestResult? { history.first }
 
@@ -786,9 +849,10 @@ struct SpeedTestQuickCard: View {
                     .clipShape(Capsule())
                 }
             }
+            .accessibilityIdentifier("dashboard_card_speedTest")
         }
         .buttonStyle(PlainButtonStyle())
-        .accessibilityIdentifier("dashboard_card_speedTest")
+        .accessibilityIdentifier("dashboard_link_speedTest")
     }
 }
 
@@ -849,9 +913,10 @@ struct WiFiHeatmapQuickCard: View {
                     .clipShape(Capsule())
                 }
             }
+            .accessibilityIdentifier("dashboard_card_wifiHeatmap")
         }
         .buttonStyle(PlainButtonStyle())
-        .accessibilityIdentifier("dashboard_card_wifiHeatmap")
+        .accessibilityIdentifier("dashboard_link_heatmap")
     }
 }
 
@@ -923,12 +988,24 @@ struct EventRow: View {
 extension DiscoveredDevice {
     var iconName: String {
         let name = self.displayName.lowercased()
-        if name.contains("iphone") { return "iphone" }
-        if name.contains("macbook") || name.contains("mac") { return "laptopcomputer" }
-        if name.contains("ipad") { return "ipad" }
-        if name.contains("tv") { return "appletv" }
-        if name.contains("homepod") { return "homepod.fill" }
-        if name.contains("printer") || name.contains("jet") { return "printer" }
+        if name.contains("iphone") {
+            return "iphone"
+        }
+        if name.contains("macbook") || name.contains("mac") {
+            return "laptopcomputer"
+        }
+        if name.contains("ipad") {
+            return "ipad"
+        }
+        if name.contains("tv") {
+            return "appletv"
+        }
+        if name.contains("homepod") {
+            return "homepod.fill"
+        }
+        if name.contains("printer") || name.contains("jet") {
+            return "printer"
+        }
         return "desktopcomputer"
     }
 }

--- a/NetMonitor-iOS/Views/Settings/SettingsView.swift
+++ b/NetMonitor-iOS/Views/Settings/SettingsView.swift
@@ -4,9 +4,6 @@ import NetMonitorCore
 
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query private var toolResults: [ToolResult]
-    @Query private var speedTestResults: [SpeedTestResult]
-    @Query private var devices: [LocalDevice]
     @State private var viewModel = SettingsViewModel()
     // Observe ThemeManager so accent color changes re-render this view
     private var themeManager = ThemeManager.shared
@@ -381,10 +378,13 @@ struct SettingsView: View {
     }
 
     private func exportFullReportAsPDF() {
+        let devices = (try? modelContext.fetch(FetchDescriptor<LocalDevice>())) ?? []
+        let toolResults = (try? modelContext.fetch(FetchDescriptor<ToolResult>())) ?? []
+        let speedTestResults = (try? modelContext.fetch(FetchDescriptor<SpeedTestResult>())) ?? []
         guard let data = DataExportService.exportFullReportAsPDF(
-            devices: Array(devices),
-            toolResults: Array(toolResults),
-            speedTests: Array(speedTestResults)
+            devices: devices,
+            toolResults: toolResults,
+            speedTests: speedTestResults
         ),
         let url = DataExportService.writeToTempFile(data: data, name: "netmonitor-report", ext: "pdf") else { return }
         exportFileURL = url
@@ -397,12 +397,15 @@ struct SettingsView: View {
 
         switch option {
         case .toolResults:
+            let toolResults = (try? modelContext.fetch(FetchDescriptor<ToolResult>())) ?? []
             data = DataExportService.exportToolResults(toolResults, format: format)
             name = "netmonitor-tool-results"
         case .speedTests:
+            let speedTestResults = (try? modelContext.fetch(FetchDescriptor<SpeedTestResult>())) ?? []
             data = DataExportService.exportSpeedTests(speedTestResults, format: format)
             name = "netmonitor-speed-tests"
         case .devices:
+            let devices = (try? modelContext.fetch(FetchDescriptor<LocalDevice>())) ?? []
             data = DataExportService.exportDevices(devices, format: format)
             name = "netmonitor-devices"
         }

--- a/NetMonitor-iOS/Views/Tools/SpeedTestToolView.swift
+++ b/NetMonitor-iOS/Views/Tools/SpeedTestToolView.swift
@@ -4,9 +4,17 @@ import SwiftData
 
 /// Speed Test tool view for measuring download/upload speed and latency
 struct SpeedTestToolView: View {
+    private static var historyDescriptor: FetchDescriptor<SpeedTestResult> {
+        var descriptor = FetchDescriptor<SpeedTestResult>(
+            sortBy: [SortDescriptor(\SpeedTestResult.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = 10
+        return descriptor
+    }
+
     @State private var viewModel = SpeedTestToolViewModel()
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \SpeedTestResult.timestamp, order: .reverse) private var history: [SpeedTestResult]
+    @Query(Self.historyDescriptor) private var history: [SpeedTestResult]
 
     var body: some View {
         ScrollView {

--- a/NetMonitor-macOS/App/NetMonitorApp.swift
+++ b/NetMonitor-macOS/App/NetMonitorApp.swift
@@ -44,11 +44,13 @@ struct NetMonitorApp: App {
            env["CI"] == "true" {
             return true
         }
-        if NSClassFromString("XCTest") != nil { return true }
+        if NSClassFromString("XCTest") != nil {
+            return true
+        }
         return false
     }
 
-    private static let sharedModelContainer: ModelContainer = {
+    private static let persistenceOutcome: PersistenceBootstrapOutcome<ModelContainer> = {
         let schema = Schema(versionedSchema: SchemaV1.self)
         let isTestEnv = NSClassFromString("XCTest") != nil
         let modelConfiguration = ModelConfiguration(
@@ -58,31 +60,36 @@ struct NetMonitorApp: App {
         )
 
         do {
-            // launch-time "Duplicate version checksums detected" exception.
-            return try ModelContainer(
-                for: schema,
-                migrationPlan: NetMonitorMigrationPlan.self,
-                configurations: [modelConfiguration]
+            return try PersistenceBootstrap.load(
+                persistentStore: {
+                    try ModelContainer(
+                        for: schema,
+                        migrationPlan: NetMonitorMigrationPlan.self,
+                        configurations: [modelConfiguration]
+                    )
+                },
+                fallbackStore: {
+                    let fallback = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+                    return try ModelContainer(
+                        for: schema,
+                        migrationPlan: NetMonitorMigrationPlan.self,
+                        configurations: [fallback]
+                    )
+                }
             )
         } catch {
-            Logger.app.warning("Could not create persistent ModelContainer: \(error)")
-            do {
-                let inMemoryConfig = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-                return try ModelContainer(
-                    for: schema,
-                    migrationPlan: NetMonitorMigrationPlan.self,
-                    configurations: [inMemoryConfig]
-                )
-            } catch {
-                fatalError("Could not create in-memory ModelContainer: \(error)")
-            }
+            fatalError("Could not create recovery ModelContainer: \(error)")
         }
     }()
+
+    private static var sharedModelContainer: ModelContainer { persistenceOutcome.store }
 
     var body: some Scene {
         WindowGroup(id: "main") {
             Group {
-                if let monitoringSession, let deviceDiscovery {
+                if let recovery = Self.persistenceOutcome.recovery {
+                    PersistenceRecoveryView(recovery: recovery)
+                } else if let monitoringSession, let deviceDiscovery {
                     ContentView()
                         .environment(monitoringSession)
                         .environment(deviceDiscovery)
@@ -97,7 +104,8 @@ struct NetMonitorApp: App {
                 // doesn't need real services, and seeding NetworkTargets
                 // into the shared container causes SwiftData crashes
                 // when test containers reset.
-                guard NSClassFromString("XCTest") == nil else { return }
+                guard NSClassFromString("XCTest") == nil,
+                      !Self.persistenceOutcome.isDegraded else { return }
                 await setupServices()
             }
             // Apply appearance based on user preference (.system = follow macOS,

--- a/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
+++ b/NetMonitor-macOS/Platform/DeviceDiscoveryCoordinator.swift
@@ -148,26 +148,24 @@ final class DeviceDiscoveryCoordinator {
     }
 
     func mergeDiscoveredDevices(_ devices: [LocalDiscoveredDevice], profileID: UUID?) {
-        for discovered in devices {
-            let predicate: Predicate<LocalDevice>
-            if !discovered.macAddress.isEmpty {
-                let mac = discovered.macAddress
-                if let profileID {
-                    predicate = #Predicate<LocalDevice> { $0.networkProfileID == profileID && $0.macAddress == mac }
-                } else {
-                    predicate = #Predicate<LocalDevice> { $0.networkProfileID == nil && $0.macAddress == mac }
-                }
-            } else {
-                let ip = discovered.ipAddress
-                if let profileID {
-                    predicate = #Predicate<LocalDevice> { $0.networkProfileID == profileID && $0.ipAddress == ip }
-                } else {
-                    predicate = #Predicate<LocalDevice> { $0.networkProfileID == nil && $0.ipAddress == ip }
-                }
+        let existingDevices = fetchDevices(for: profileID)
+        var devicesByMAC: [String: LocalDevice] = [:]
+        var devicesByIP: [String: LocalDevice] = [:]
+        for device in existingDevices {
+            let mac = device.macAddress.uppercased()
+            if !mac.isEmpty, devicesByMAC[mac] == nil {
+                devicesByMAC[mac] = device
             }
+            if devicesByIP[device.ipAddress] == nil {
+                devicesByIP[device.ipAddress] = device
+            }
+        }
 
-            let descriptor = FetchDescriptor<LocalDevice>(predicate: predicate)
-            let existing = try? modelContext.fetch(descriptor).first
+        for discovered in devices {
+            let normalizedMAC = discovered.macAddress.uppercased()
+            let existing = normalizedMAC.isEmpty
+                ? devicesByIP[discovered.ipAddress]
+                : devicesByMAC[normalizedMAC]
 
             if let existing {
                 existing.ipAddress = discovered.ipAddress
@@ -186,6 +184,10 @@ final class DeviceDiscoveryCoordinator {
                     networkProfileID: profileID
                 )
                 modelContext.insert(newDevice)
+                devicesByIP[newDevice.ipAddress] = newDevice
+                if !normalizedMAC.isEmpty {
+                    devicesByMAC[normalizedMAC] = newDevice
+                }
             }
         }
 

--- a/NetMonitor-macOS/Platform/ISPLookupService.swift
+++ b/NetMonitor-macOS/Platform/ISPLookupService.swift
@@ -32,9 +32,7 @@ actor ISPLookupService {
     private let cacheKey = "netmonitor.isp.cache"
     private let cacheValidityDuration: TimeInterval = 5 * 60 // 5 minutes
 
-    // swiftlint:disable:next force_unwrapping
     private let primaryURL = URL(string: "https://ipapi.co/json/")!
-    // swiftlint:disable:next force_unwrapping
     private let fallbackURL = URL(string: "https://ipinfo.io/json")!
 
     // MARK: - Public API

--- a/NetMonitor-macOS/Utilities/LocalDeviceQueries.swift
+++ b/NetMonitor-macOS/Utilities/LocalDeviceQueries.swift
@@ -11,14 +11,6 @@ enum LocalDeviceQueries {
     /// Default row cap applied to summary and picker views.
     static let defaultLimit = 500
 
-    /// All devices sorted by most-recently-seen first, with no row cap.
-    /// Use for full-table views where users expect to see every device.
-    static func all() -> FetchDescriptor<LocalDevice> {
-        FetchDescriptor<LocalDevice>(
-            sortBy: [SortDescriptor(\LocalDevice.lastSeen, order: .reverse)]
-        )
-    }
-
     /// Most-recently-seen devices sorted by `lastSeen` descending, capped at `limit`.
     /// Use for summary views that don't need the full table.
     static func recents(limit: Int = defaultLimit) -> FetchDescriptor<LocalDevice> {

--- a/NetMonitor-macOS/Views/Components/PersistenceRecoveryView.swift
+++ b/NetMonitor-macOS/Views/Components/PersistenceRecoveryView.swift
@@ -1,0 +1,28 @@
+import NetMonitorCore
+import SwiftUI
+
+struct PersistenceRecoveryView: View {
+    let recovery: PersistenceRecoveryState
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(recovery.title, systemImage: "externaldrive.badge.exclamationmark")
+        } description: {
+            Text(recovery.message)
+        } actions: {
+            ShareLink(item: recovery.diagnosticText) {
+                Label("Export Diagnostics", systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("persistenceRecovery_button_exportDiagnostics")
+
+            Text("Quit and reopen NetMonitor to retry. If this screen returns, export diagnostics before reinstalling.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(minWidth: 520, minHeight: 360)
+        .padding()
+        .accessibilityIdentifier("persistenceRecovery_screen")
+    }
+}

--- a/NetMonitor-macOS/Views/DevicesView.swift
+++ b/NetMonitor-macOS/Views/DevicesView.swift
@@ -13,7 +13,7 @@ struct DevicesView: View {
     @Environment(DeviceDiscoveryCoordinator.self) private var coordinator: DeviceDiscoveryCoordinator?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Query(LocalDeviceQueries.all()) private var devices: [LocalDevice]
+    @State private var devices: [LocalDevice] = []
 
     @State private var selectedDevice: LocalDevice?
     @State private var searchText: String = ""
@@ -168,23 +168,45 @@ struct DevicesView: View {
         .sheet(item: $deviceToPing) { device in
             DevicePingSheet(device: device, isPresented: Binding(
                 get: { deviceToPing != nil },
-                set: { if !$0 { deviceToPing = nil } }
+                set: {
+                    if !$0 {
+                        deviceToPing = nil
+                    }
+                }
             ))
         }
         .sheet(item: $deviceToScan) { device in
             DevicePortScanSheet(device: device, isPresented: Binding(
                 get: { deviceToScan != nil },
-                set: { if !$0 { deviceToScan = nil } }
+                set: {
+                    if !$0 {
+                        deviceToScan = nil
+                    }
+                }
             ))
         }
         .onReceive(NotificationCenter.default.publisher(for: .networkProfilesDidChange)) { _ in
             availableNetworks = coordinator?.networkProfileManager.profiles
                 ?? NetworkProfileManager.detectActiveProfiles()
+            reloadDevices()
         }
         .onAppear {
             availableNetworks = coordinator?.networkProfileManager.profiles
                 ?? NetworkProfileManager.detectActiveProfiles()
+            reloadDevices()
         }
+        .onChange(of: selectedNetworkID) {
+            reloadDevices()
+        }
+        .onChange(of: coordinator?.isScanning) { _, isScanning in
+            if isScanning == false {
+                reloadDevices()
+            }
+        }
+    }
+
+    private func reloadDevices() {
+        devices = (try? modelContext.fetch(LocalDeviceQueries.forProfile(activeProfileID))) ?? []
     }
 
     // MARK: - Device List
@@ -402,6 +424,7 @@ struct DevicesView: View {
                 TextField("Search...", text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))
+                    .accessibilityIdentifier("devices_textfield_search")
                 if !searchText.isEmpty {
                     Button {
                         searchText = ""

--- a/NetMonitor-macOS/Views/Tools/PortScannerToolView.swift
+++ b/NetMonitor-macOS/Views/Tools/PortScannerToolView.swift
@@ -321,6 +321,7 @@ struct PortScannerToolView: View {
     }
 
     private func checkPort(host: String, port: UInt16) async -> PortResult? {
+        guard !Task.isCancelled else { return nil }
         let startTime = Date()
 
         guard let nwPort = NWEndpoint.Port(rawValue: port) else {
@@ -334,25 +335,49 @@ struct PortScannerToolView: View {
 
         let connection = NWConnection(to: endpoint, using: .tcp)
 
-        return await withCheckedContinuation { continuation in
-            let tracker = ContinuationTracker()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let tracker = ContinuationTracker()
 
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    connection.cancel()
-                    if tracker.tryResume() {
-                        let latency = Date().timeIntervalSince(startTime)
-                        continuation.resume(returning: PortResult(
-                            port: port,
-                            isOpen: true,
-                            latency: latency,
-                            serviceName: Self.serviceName(for: port)
-                        ))
+                connection.stateUpdateHandler = { state in
+                    switch state {
+                    case .ready:
+                        connection.cancel()
+                        if tracker.tryResume() {
+                            let latency = Date().timeIntervalSince(startTime)
+                            continuation.resume(returning: PortResult(
+                                port: port,
+                                isOpen: true,
+                                latency: latency,
+                                serviceName: Self.serviceName(for: port)
+                            ))
+                        }
+
+                    case .failed, .cancelled:
+                        if tracker.tryResume() {
+                            continuation.resume(returning: PortResult(
+                                port: port,
+                                isOpen: false,
+                                latency: 0,
+                                serviceName: Self.serviceName(for: port)
+                            ))
+                        }
+
+                    default:
+                        break
                     }
+                }
 
-                case .failed, .cancelled:
+                connection.start(queue: DispatchQueue(label: "com.netmonitor.port-scanner"))
+
+                Task {
+                    do {
+                        try await Task.sleep(for: .seconds(2))
+                    } catch {
+                        return
+                    }
                     if tracker.tryResume() {
+                        connection.cancel()
                         continuation.resume(returning: PortResult(
                             port: port,
                             isOpen: false,
@@ -360,26 +385,10 @@ struct PortScannerToolView: View {
                             serviceName: Self.serviceName(for: port)
                         ))
                     }
-
-                default:
-                    break
                 }
             }
-
-            connection.start(queue: .global())
-
-            // Timeout after 2 seconds
-            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-                if tracker.tryResume() {
-                    connection.cancel()
-                    continuation.resume(returning: PortResult(
-                        port: port,
-                        isOpen: false,
-                        latency: 0,
-                        serviceName: Self.serviceName(for: port)
-                    ))
-                }
-            }
+        } onCancel: {
+            connection.cancel()
         }
     }
 

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/CompanionFrameDecoder.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/CompanionFrameDecoder.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum CompanionFrameError: Equatable, Sendable {
+    case invalidLength(UInt32)
+    case malformedPayload
+}
+
+public struct CompanionFrameBatch: Sendable {
+    public let messages: [CompanionMessage]
+    public let errors: [CompanionFrameError]
+
+    public init(messages: [CompanionMessage], errors: [CompanionFrameError]) {
+        self.messages = messages
+        self.errors = errors
+    }
+}
+
+/// Incremental length-prefixed decoder isolated from UI actors.
+public actor CompanionFrameDecoder {
+    public static let defaultMaximumFrameSize = 1_048_576
+
+    private let maximumFrameSize: Int
+    private var buffer = Data()
+
+    public init(maximumFrameSize: Int = defaultMaximumFrameSize) {
+        self.maximumFrameSize = maximumFrameSize
+    }
+
+    public func append(_ incoming: Data) -> CompanionFrameBatch {
+        buffer.append(incoming)
+        var messages: [CompanionMessage] = []
+        var errors: [CompanionFrameError] = []
+
+        while buffer.count >= 4 {
+            let start = buffer.startIndex
+            let length = UInt32(buffer[start]) << 24
+                | UInt32(buffer[start + 1]) << 16
+                | UInt32(buffer[start + 2]) << 8
+                | UInt32(buffer[start + 3])
+
+            guard length > 0, length <= maximumFrameSize else {
+                errors.append(.invalidLength(length))
+                buffer.removeAll(keepingCapacity: false)
+                break
+            }
+
+            let frameSize = 4 + Int(length)
+            guard buffer.count >= frameSize else { break }
+
+            let payloadStart = start + 4
+            let frameEnd = start + frameSize
+            let payload = buffer.subdata(in: payloadStart..<frameEnd)
+            buffer.removeSubrange(start..<frameEnd)
+
+            do {
+                try messages.append(CompanionMessage.decode(from: payload))
+            } catch {
+                errors.append(.malformedPayload)
+            }
+        }
+
+        return CompanionFrameBatch(messages: messages, errors: errors)
+    }
+
+    public func reset() {
+        buffer.removeAll(keepingCapacity: false)
+    }
+}

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/PersistenceBootstrap.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/PersistenceBootstrap.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// User-facing state emitted when the primary persistent store cannot open.
+public struct PersistenceRecoveryState: Equatable, Sendable {
+    public let title: String
+    public let message: String
+    public let diagnosticText: String
+
+    public init(title: String, message: String, diagnosticText: String) {
+        self.title = title
+        self.message = message
+        self.diagnosticText = diagnosticText
+    }
+}
+
+/// Result of opening a persistent store, including an explicit degraded state
+/// when an ephemeral fallback had to be used.
+public struct PersistenceBootstrapOutcome<Store> {
+    public let store: Store
+    public let recovery: PersistenceRecoveryState?
+
+    public var isDegraded: Bool { recovery != nil }
+
+    public init(store: Store, recovery: PersistenceRecoveryState?) {
+        self.store = store
+        self.recovery = recovery
+    }
+}
+
+public enum PersistenceBootstrap {
+    /// Attempts the primary persistent store first. If that fails, creates a
+    /// temporary fallback and returns a visible recovery state so callers never
+    /// mistake an in-memory session for durable storage.
+    public static func load<Store>(
+        persistentStore: () throws -> Store,
+        fallbackStore: () throws -> Store
+    ) throws -> PersistenceBootstrapOutcome<Store> {
+        do {
+            return try PersistenceBootstrapOutcome(store: persistentStore(), recovery: nil)
+        } catch {
+            let persistentStoreError = error
+            let fallback = try fallbackStore()
+            let diagnosticText = """
+            NetMonitor persistent store recovery
+            Timestamp: \(Date().formatted(.iso8601))
+            Error: \(String(reflecting: persistentStoreError))
+            """
+            let recovery = PersistenceRecoveryState(
+                title: "Data Store Needs Attention",
+                message: "NetMonitor could not open its saved data. No changes will be persisted until the store is repaired. Your existing store has not been deleted.",
+                diagnosticText: diagnosticText
+            )
+            return PersistenceBootstrapOutcome(store: fallback, recovery: recovery)
+        }
+    }
+}

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/ScanProgressCoalescer.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/ScanProgressCoalescer.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Deterministic gate for coalescing high-frequency scan progress updates.
+/// Phase transitions and completion are always published.
+public struct ScanProgressCoalescer: Sendable {
+    private let minimumInterval: TimeInterval
+    private var lastPublishedAt: TimeInterval?
+    private var lastPhase: String?
+
+    public init(minimumInterval: TimeInterval = 0.1) {
+        self.minimumInterval = minimumInterval
+    }
+
+    public mutating func shouldPublish(
+        progress: Double,
+        phase: String,
+        timestamp: TimeInterval
+    ) -> Bool {
+        let phaseChanged = phase != lastPhase
+        let intervalElapsed = lastPublishedAt.map { timestamp - $0 >= minimumInterval } ?? true
+        guard phaseChanged || progress >= 1 || intervalElapsed else { return false }
+
+        lastPhase = phase
+        lastPublishedAt = timestamp
+        return true
+    }
+}

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/BonjourDiscoveryService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/BonjourDiscoveryService.swift
@@ -213,7 +213,7 @@ public final class BonjourDiscoveryService: BonjourDiscoveryServiceProtocol {
     // MARK: - Service resolution
 
     nonisolated public func resolveService(_ service: BonjourService) async -> BonjourService? {
-        await ConnectionBudget.shared.acquire()
+        guard await ConnectionBudget.shared.acquire() else { return nil }
         defer { Task { await ConnectionBudget.shared.release() } }
 
         let endpoint = NWEndpoint.service(

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/DeviceDiscoveryService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/DeviceDiscoveryService.swift
@@ -45,6 +45,7 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
 
     private var scanTask: Task<Void, Never>?
     private var cachedDevicesByProfileID: [String: [DiscoveredDevice]] = [:]
+    private var progressCoalescer = ScanProgressCoalescer()
 
     private static let deviceCacheStorageKey = "netmonitor.deviceCacheByProfileID"
 
@@ -100,8 +101,12 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
     ) async {
         let devices = await engine.accumulator.snapshot().map { withProfile($0, profileID: profileID) }
         self.discoveredDevices = devices
-        if let progress { self.scanProgress = progress }
-        if let phase { self.scanPhase = phase }
+        if let progress {
+            self.scanProgress = progress
+        }
+        if let phase {
+            self.scanPhase = phase
+        }
     }
 
     // MARK: - Public API
@@ -134,6 +139,7 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
         scanProgress = 0
         scanPhase = .arpScan
         discoveredDevices = staleDevices
+        progressCoalescer = ScanProgressCoalescer()
 
         defer {
             isScanning = false
@@ -157,6 +163,7 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
         // Start Bonjour discovery early — runs during ARP + TCP phases
         let bonjourService = BonjourDiscoveryService()
         bonjourService.startDiscovery()
+        defer { bonjourService.stopDiscovery() }
 
         // Build ScanContext — use the profile's interface for local IP detection
         let filter = scanTarget.filter
@@ -188,6 +195,16 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
         // Run the scan engine
         let engineRef = engine
         _ = await engineRef.scan(pipeline: pipeline, context: context) { [weak self] progress, phaseName in
+            let shouldPublish = await MainActor.run {
+                guard let self else { return false }
+                return self.progressCoalescer.shouldPublish(
+                    progress: progress,
+                    phase: phaseName,
+                    timestamp: ProcessInfo.processInfo.systemUptime
+                )
+            }
+            guard shouldPublish else { return }
+
             let snapshot = await engineRef.accumulator.snapshot()
             await MainActor.run {
                 guard let self else { return }
@@ -199,6 +216,8 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
             }
         }
 
+        guard !Task.isCancelled else { return }
+
         // Phase: Mac companion merge
         scanPhase = .companion
         scanProgress = 0.90
@@ -208,6 +227,7 @@ public final class DeviceDiscoveryService: DeviceDiscoveryServiceProtocol {
             await macConnectionService?.send(command: CommandPayload(action: .refreshDevices))
             try? await Task.sleep(for: .seconds(1))
         }
+        guard !Task.isCancelled else { return }
         await mergeCompanionDevices(filter: scanTarget.filter, profileID: profileID)
         await flushToMainActor(progress: 0.95, profileID: profileID)
 

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/PingService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/PingService.swift
@@ -221,7 +221,9 @@ public actor PingService: PingServiceProtocol {
         return await withTaskGroup(of: (Bool, TimeInterval).self, returning: (Bool, TimeInterval).self) { group in
             for port in ports {
                 group.addTask {
-                    await ConnectionBudget.shared.acquire()
+                    guard await ConnectionBudget.shared.acquire() else {
+                        return (false, timeout)
+                    }
                     let connection = NWConnection(to: .hostPort(host: hostEndpoint, port: port), using: .tcp)
                     defer {
                         connection.cancel()

--- a/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/PortScannerService.swift
+++ b/Packages/NetMonitorCore/Sources/NetMonitorCore/Services/PortScannerService.swift
@@ -66,7 +66,15 @@ public actor PortScannerService: PortScannerServiceProtocol {
     }
 
     private func scanPort(host: String, port: Int, timeout: TimeInterval) async -> PortScanResult {
-        await ConnectionBudget.shared.acquire()
+        guard await ConnectionBudget.shared.acquire() else {
+            return PortScanResult(
+                port: port,
+                state: .filtered,
+                serviceName: PortScanResult.commonServiceName(for: port),
+                banner: nil,
+                responseTime: nil
+            )
+        }
         defer { Task { await ConnectionBudget.shared.release() } }
 
         let start = Date()

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/CompanionFrameDecoderTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/CompanionFrameDecoderTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import NetMonitorCore
+
+struct CompanionFrameDecoderTests {
+    @Test("decoder handles fragmented and adjacent frames")
+    func fragmentedAdjacentFrames() async throws {
+        let decoder = CompanionFrameDecoder(maximumFrameSize: 1_024)
+        let first = try CompanionMessage.heartbeat(HeartbeatPayload(timestamp: Date(), version: "1")).encodeLengthPrefixed()
+        let second = try CompanionMessage.error(ErrorPayload(code: "fixture", message: "fixture")).encodeLengthPrefixed()
+
+        let partial = await decoder.append(Data(first.prefix(2)))
+        #expect(partial.messages.isEmpty)
+
+        var remainder = Data(first.dropFirst(2))
+        remainder.append(second)
+        let decoded = await decoder.append(remainder)
+
+        #expect(decoded.messages.count == 2)
+        #expect(decoded.errors.isEmpty)
+    }
+
+    @Test("oversized frame is rejected and does not poison the next frame")
+    func oversizedFrameResetsBuffer() async throws {
+        let decoder = CompanionFrameDecoder(maximumFrameSize: 128)
+
+        let rejected = await decoder.append(Data([0, 0, 1, 0]))
+        #expect(rejected.errors == [.invalidLength(256)])
+
+        let valid = try CompanionMessage.heartbeat(HeartbeatPayload(timestamp: Date(), version: "1")).encodeLengthPrefixed()
+        let decoded = await decoder.append(valid)
+        #expect(decoded.messages.count == 1)
+    }
+}

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/LastShippedStoreCompatibilityTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/LastShippedStoreCompatibilityTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import NetMonitorCore
+
+@MainActor
+struct LastShippedStoreCompatibilityTests {
+    @Test("v2.2.0 iOS schema store reopens without data loss")
+    func iOSStoreReopens() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "netmonitor-v220-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let storeURL = directory.appending(path: "v2.2.0.store")
+        let schema = Schema([
+            PairedMac.self,
+            LocalDevice.self,
+            MonitoringTarget.self,
+            ToolResult.self,
+            SpeedTestResult.self
+        ])
+        let fixtureID = UUID()
+
+        do {
+            let configuration = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+            let container = try ModelContainer(for: schema, configurations: [configuration])
+            container.mainContext.insert(ToolResult(
+                id: fixtureID,
+                toolType: .ping,
+                target: "fixture.invalid",
+                success: true,
+                summary: "v2.2.0 fixture"
+            ))
+            try container.mainContext.save()
+        }
+
+        let configuration = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+        let reopened = try ModelContainer(for: schema, configurations: [configuration])
+        let results = try reopened.mainContext.fetch(FetchDescriptor<ToolResult>())
+
+        #expect(results.map(\.id).contains(fixtureID))
+    }
+}

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/PersistenceBootstrapTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/PersistenceBootstrapTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import NetMonitorCore
+
+struct PersistenceBootstrapTests {
+    private enum FixtureError: Error {
+        case persistentStoreUnavailable
+    }
+
+    @Test("successful persistent store does not enter recovery mode")
+    func persistentStoreSuccess() throws {
+        var fallbackWasCalled = false
+
+        let outcome = try PersistenceBootstrap.load(
+            persistentStore: { "persistent" },
+            fallbackStore: {
+                fallbackWasCalled = true
+                return "fallback"
+            }
+        )
+
+        #expect(outcome.store == "persistent")
+        #expect(!outcome.isDegraded)
+        #expect(outcome.recovery == nil)
+        #expect(!fallbackWasCalled)
+    }
+
+    @Test("persistent store failure is visible when fallback succeeds")
+    func persistentStoreFailureEntersRecovery() throws {
+        let outcome = try PersistenceBootstrap.load(
+            persistentStore: { throw FixtureError.persistentStoreUnavailable },
+            fallbackStore: { "temporary" }
+        )
+
+        #expect(outcome.store == "temporary")
+        #expect(outcome.isDegraded)
+        #expect(outcome.recovery?.title == "Data Store Needs Attention")
+        #expect(outcome.recovery?.diagnosticText.contains("persistentStoreUnavailable") == true)
+    }
+
+    @Test("fallback failure is propagated")
+    func fallbackFailurePropagates() {
+        #expect(throws: FixtureError.self) {
+            _ = try PersistenceBootstrap.load(
+                persistentStore: { throw FixtureError.persistentStoreUnavailable },
+                fallbackStore: { throw FixtureError.persistentStoreUnavailable }
+            ) as PersistenceBootstrapOutcome<String>
+        }
+    }
+}

--- a/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/ScanProgressCoalescerTests.swift
+++ b/Packages/NetMonitorCore/Tests/NetMonitorCoreTests/ScanProgressCoalescerTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import NetMonitorCore
+
+struct ScanProgressCoalescerTests {
+    @Test("publishes at most ten same-phase updates per second")
+    func throttlesSamePhaseUpdates() {
+        var coalescer = ScanProgressCoalescer(minimumInterval: 0.1)
+
+        let first = coalescer.shouldPublish(progress: 0, phase: "TCP", timestamp: 1.0)
+        let early = coalescer.shouldPublish(progress: 0.1, phase: "TCP", timestamp: 1.05)
+        let afterInterval = coalescer.shouldPublish(progress: 0.2, phase: "TCP", timestamp: 1.1)
+
+        #expect(first)
+        #expect(!early)
+        #expect(afterInterval)
+    }
+
+    @Test("phase transitions and completion publish immediately")
+    func phaseAndCompletionBypassThrottle() {
+        var coalescer = ScanProgressCoalescer(minimumInterval: 0.1)
+
+        let first = coalescer.shouldPublish(progress: 0.1, phase: "ARP", timestamp: 1.0)
+        let nextPhase = coalescer.shouldPublish(progress: 0.2, phase: "TCP", timestamp: 1.01)
+        let completion = coalescer.shouldPublish(progress: 1, phase: "TCP", timestamp: 1.02)
+
+        #expect(first)
+        #expect(nextPhase)
+        #expect(completion)
+    }
+}

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/ConnectionBudget.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/ConnectionBudget.swift
@@ -1,4 +1,17 @@
 import Foundation
+import os
+
+private final class ConnectionWaiterState: @unchecked Sendable {
+    private let isCancelledLock = OSAllocatedUnfairLock(initialState: false)
+
+    var isCancelled: Bool {
+        isCancelledLock.withLock { $0 }
+    }
+
+    func cancel() {
+        isCancelledLock.withLock { $0 = true }
+    }
+}
 
 /// Global connection budget that caps the number of concurrent NWConnections
 /// across all services to prevent kernel socket exhaustion, reduce CPU heat,
@@ -11,7 +24,13 @@ public actor ConnectionBudget {
 
     private let limit: Int
     private var active = 0
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private struct Waiter {
+        let id: UUID
+        let state: ConnectionWaiterState
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var waiters: [Waiter] = []
 
     public init(limit: Int) {
         self.limit = limit
@@ -23,15 +42,37 @@ public actor ConnectionBudget {
     }
 
     /// Wait until a connection slot is available, then claim it.
-    public func acquire() async {
+    @discardableResult
+    public func acquire() async -> Bool {
+        guard !Task.isCancelled else { return false }
+
         if active < effectiveLimit {
             active += 1
-            return
+            return true
         }
-        await withCheckedContinuation { cont in
-            waiters.append(cont)
+
+        let id = UUID()
+        let waiterState = ConnectionWaiterState()
+        let acquired = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                waiters.append(Waiter(id: id, state: waiterState, continuation: continuation))
+            }
+        } onCancel: {
+            waiterState.cancel()
+            Task { await self.cancelWaiter(id: id) }
         }
-        active += 1
+
+        guard acquired, !Task.isCancelled else {
+            if acquired {
+                release()
+            }
+            return false
+        }
+        return true
     }
 
     /// Release a connection slot, waking the next waiter if any.
@@ -40,11 +81,16 @@ public actor ConnectionBudget {
     /// throttling reduced `effectiveLimit` since the waiter was enqueued.
     /// This prevents deadlock when the thermal state changes mid-scan.
     public func release() {
-        active = max(active - 1, 0)
-        if !waiters.isEmpty {
+        while !waiters.isEmpty {
             let next = waiters.removeFirst()
-            next.resume()
+            guard !next.state.isCancelled else {
+                next.continuation.resume(returning: false)
+                continue
+            }
+            next.continuation.resume(returning: true)
+            return
         }
+        active = max(active - 1, 0)
     }
 
     /// Force-drain all waiters and reset the active count.
@@ -54,10 +100,19 @@ public actor ConnectionBudget {
         let pending = waiters
         waiters.removeAll()
         for waiter in pending {
-            waiter.resume()
+            waiter.continuation.resume(returning: false)
         }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
     }
 
     /// Current number of active connections (for diagnostics).
     public var activeCount: Int { active }
+
+    /// Current number of tasks waiting for a connection slot (for diagnostics).
+    public var waitingCount: Int { waiters.count }
 }

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/NWConnectionHelper.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/NWConnectionHelper.swift
@@ -11,6 +11,49 @@ enum NWConnectionResolution<T: Sendable> {
     case completeKeepAlive(T)
 }
 
+private actor NWConnectionOperationState<Value: Sendable> {
+    private struct StoredValue: Sendable {
+        let value: Value
+    }
+
+    private var continuation: CheckedContinuation<Value, Never>?
+    private var pendingValue: StoredValue?
+    private var isResolved = false
+    private var timeoutTask: Task<Void, Never>?
+
+    func install(_ continuation: CheckedContinuation<Value, Never>) {
+        if isResolved, let pendingValue {
+            continuation.resume(returning: pendingValue.value)
+            self.pendingValue = nil
+        } else {
+            self.continuation = continuation
+        }
+    }
+
+    func setTimeoutTask(_ task: Task<Void, Never>) {
+        if isResolved {
+            task.cancel()
+        } else {
+            timeoutTask = task
+        }
+    }
+
+    @discardableResult
+    func resolve(_ value: Value) -> Bool {
+        guard !isResolved else { return false }
+        isResolved = true
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        if let continuation {
+            continuation.resume(returning: value)
+            self.continuation = nil
+        } else {
+            pendingValue = StoredValue(value: value)
+        }
+        return true
+    }
+}
+
 /// Awaits the first relevant state transition on `connection` and returns the value
 /// produced by `classify`, or `timeoutValue` after `timeout` elapses.
 ///
@@ -30,31 +73,44 @@ func withNWConnection<T: Sendable>(
     timeoutValue: T,
     classify: @escaping @Sendable (NWConnection.State) -> NWConnectionResolution<T>?
 ) async -> T {
-    await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
-        let resumed = ResumeState()
+    let operationState = NWConnectionOperationState<T>()
 
-        let timeoutTask = Task {
-            try? await Task.sleep(for: timeout)
-            guard await resumed.tryResume() else { return }
-            connection.cancel()
-            continuation.resume(returning: timeoutValue)
-        }
-
-        connection.stateUpdateHandler = { state in
-            guard let resolution = classify(state) else { return }
+    return await withTaskCancellationHandler {
+        await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
             Task {
-                guard await resumed.tryResume() else { return }
-                timeoutTask.cancel()
-                switch resolution {
-                case .complete(let value):
-                    connection.cancel()
-                    continuation.resume(returning: value)
-                case .completeKeepAlive(let value):
-                    continuation.resume(returning: value)
+                await operationState.install(continuation)
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(for: timeout)
+                    } catch {
+                        return
+                    }
+                    if await operationState.resolve(timeoutValue) {
+                        connection.cancel()
+                    }
+                }
+                await operationState.setTimeoutTask(timeoutTask)
+            }
+
+            connection.stateUpdateHandler = { state in
+                guard let resolution = classify(state) else { return }
+                Task {
+                    switch resolution {
+                    case .complete(let value):
+                        guard await operationState.resolve(value) else { return }
+                        connection.cancel()
+                    case .completeKeepAlive(let value):
+                        _ = await operationState.resolve(value)
+                    }
                 }
             }
-        }
 
-        connection.start(queue: queue)
+            connection.start(queue: queue)
+        }
+    } onCancel: {
+        connection.cancel()
+        Task {
+            _ = await operationState.resolve(timeoutValue)
+        }
     }
 }

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ARPScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ARPScanPhase.swift
@@ -14,14 +14,17 @@ public struct ARPScanPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         // Fire UDP probes to populate the ARP cache
         ARPCacheScanner.populateARPCache(hosts: context.hosts)
+        guard !Task.isCancelled else { return }
         await onProgress(0.3)
 
         // Wait for ARP resolution
         try? await Task.sleep(for: .seconds(2))
+        guard !Task.isCancelled else { return }
         await onProgress(0.6)
 
         // Read the ARP cache
@@ -31,6 +34,7 @@ public struct ARPScanPhase: ScanPhase, Sendable {
         // Upsert discovered devices — filter to target subnet only
         // (the ARP cache contains entries from all interfaces: VPN, Docker, stale, etc.)
         for (ip, mac) in results where context.subnetFilter(ip) {
+            guard !Task.isCancelled else { return }
             await accumulator.upsert(DiscoveredDevice(
                 ipAddress: ip,
                 hostname: nil,

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/BonjourScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/BonjourScanPhase.swift
@@ -45,6 +45,7 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         // Adaptive Bonjour collection: poll for services and exit early
@@ -57,9 +58,15 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
 
         while true {
             try? await Task.sleep(for: pollInterval)
+            guard !Task.isCancelled else {
+                await stopProvider?()
+                return
+            }
 
             let elapsed = clock.now - startInstant
-            if elapsed >= discoveryWaitDuration { break }
+            if elapsed >= discoveryWaitDuration {
+                break
+            }
 
             let services = await serviceProvider()
             let currentCount = services.count
@@ -94,6 +101,7 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
             var iterator = capped.makeIterator()
 
             while pending < maxResolveConcurrency, let service = iterator.next() {
+                guard !Task.isCancelled else { break }
                 pending += 1
                 group.addTask {
                     await Self.makeBonjourDevice(from: service, subnetFilter: context.subnetFilter)
@@ -101,6 +109,10 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
             }
 
             while pending > 0 {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
                 guard let result = await group.next() else { break }
                 pending -= 1
                 resolved += 1
@@ -131,6 +143,7 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
         from service: BonjourServiceInfo,
         subnetFilter: @Sendable (String) -> Bool
     ) async -> DiscoveredDevice? {
+        guard !Task.isCancelled else { return nil }
         guard let host = await resolveBonjourHost(for: service) else { return nil }
 
         let normalizedHost = host.split(separator: "%", maxSplits: 1).first.map(String.init) ?? host
@@ -157,7 +170,8 @@ public struct BonjourScanPhase: ScanPhase, Sendable {
     }
 
     private static func resolveBonjourHost(for service: BonjourServiceInfo) async -> String? {
-        await ConnectionBudget.shared.acquire()
+        guard !Task.isCancelled else { return nil }
+        guard await ConnectionBudget.shared.acquire() else { return nil }
         defer { Task { await ConnectionBudget.shared.release() } }
 
         let endpoint = NWEndpoint.service(

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ICMPLatencyPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ICMPLatencyPhase.swift
@@ -32,6 +32,7 @@ public struct ICMPLatencyPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         let ipsNeedingLatency = await accumulator.allDeviceIPs()
@@ -72,8 +73,11 @@ public struct ICMPLatencyPhase: ScanPhase, Sendable {
             }
         }
 
+        guard !Task.isCancelled else { return }
+
         // Batch-update accumulator — ICMP replaces any TCP-based latency
         for (ip, rtt) in results {
+            guard !Task.isCancelled else { return }
             await accumulator.replaceLatency(ip: ip, latency: rtt)
         }
 
@@ -133,7 +137,9 @@ public struct ICMPLatencyPhase: ScanPhase, Sendable {
             let pollResult = poll(&pollFd, 1, min(remainingMs, 200))
 
             guard pollResult > 0 else {
-                if remainingMs <= 1 { break }
+                if remainingMs <= 1 {
+                    break
+                }
                 continue
             }
 

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ReverseDNSScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/ReverseDNSScanPhase.swift
@@ -19,6 +19,7 @@ public struct ReverseDNSScanPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         let devices = await accumulator.snapshot()
@@ -37,6 +38,7 @@ public struct ReverseDNSScanPhase: ScanPhase, Sendable {
             var iterator = devicesNeedingNames.makeIterator()
 
             while pending < maxConcurrentResolves, let device = iterator.next() {
+                guard !Task.isCancelled else { break }
                 pending += 1
                 group.addTask {
                     let name = await nameResolver.resolve(ipAddress: device.ipAddress)
@@ -45,6 +47,10 @@ public struct ReverseDNSScanPhase: ScanPhase, Sendable {
             }
 
             for await (ip, hostname) in group {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
                 pending -= 1
                 resolved += 1
 

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/SSDPScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/SSDPScanPhase.swift
@@ -14,12 +14,15 @@ public struct SSDPScanPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         let discoveredIPs = await Self.discoverSSDP()
+        guard !Task.isCancelled else { return }
         await onProgress(0.7)
 
         for ip in discoveredIPs where context.subnetFilter(ip) {
+            guard !Task.isCancelled else { return }
             await accumulator.upsert(DiscoveredDevice(
                 ipAddress: ip,
                 hostname: nil,
@@ -38,6 +41,7 @@ public struct SSDPScanPhase: ScanPhase, Sendable {
 
     /// Send SSDP M-SEARCH multicast and collect responding device IPs.
     private static func discoverSSDP() async -> [String] {
+        guard !Task.isCancelled else { return [] }
         let multicastGroup = "239.255.255.250"
         let multicastPort: UInt16 = 1900
         let searchMessage = [
@@ -58,7 +62,7 @@ public struct SSDPScanPhase: ScanPhase, Sendable {
         let params = NWParameters.udp
         params.requiredInterfaceType = .wifi
 
-        await ConnectionBudget.shared.acquire()
+        guard await ConnectionBudget.shared.acquire() else { return [] }
         defer { Task { await ConnectionBudget.shared.release() } }
 
         let connection = NWConnection(to: endpoint, using: params)
@@ -74,6 +78,7 @@ public struct SSDPScanPhase: ScanPhase, Sendable {
         }
 
         guard ready else { return [] }
+        guard !Task.isCancelled else { return [] }
 
         // Send M-SEARCH
         connection.send(content: messageData, completion: .contentProcessed { _ in })

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/Phases/TCPProbeScanPhase.swift
@@ -36,6 +36,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         accumulator: ScanAccumulator,
         onProgress: @Sendable (Double) async -> Void
     ) async {
+        guard !Task.isCancelled else { return }
         await onProgress(0.0)
 
         // Skip IPs already found by earlier phases
@@ -59,6 +60,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             var hostIterator = hostsToProbe.makeIterator()
 
             while pending < concurrencyLimit, let ip = hostIterator.next() {
+                guard !Task.isCancelled else { break }
                 pending += 1
                 group.addTask {
                     await Self.probeHost(ip, tracker: tracker)
@@ -66,6 +68,10 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             }
 
             while let result = await group.next() {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
                 pending -= 1
                 scannedCount += 1
 
@@ -86,6 +92,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         }
 
         // Enrich already-known devices with latency via lightweight single-port probe
+        guard !Task.isCancelled else { return }
         let ipsNeedingLatency = await accumulator.ipsWithoutLatency()
         if !ipsNeedingLatency.isEmpty {
             await enrichLatency(
@@ -117,6 +124,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
 
     /// Probe a host with staged port groups, using adaptive timeouts from the RTT tracker.
     private static func probeHost(_ ip: String, tracker: RTTTracker) async -> DiscoveredDevice? {
+        guard !Task.isCancelled else { return nil }
         let primaryTimeoutMs = await tracker.adaptiveTimeout(base: basePrimaryTimeout)
         let primaryResult = await probePortGroup(
             ip: ip,
@@ -132,6 +140,8 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         case .allTimedOut, .allFailed:
             break
         }
+
+        guard !Task.isCancelled else { return nil }
 
         let secondaryTimeoutMs = await tracker.adaptiveTimeout(base: baseSecondaryTimeout)
         let secondaryResult = await probePortGroup(
@@ -156,7 +166,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
         maxConcurrentPorts: Int,
         tracker: RTTTracker
     ) async -> ProbeGroupResult {
-        guard !ports.isEmpty else { return .allFailed }
+        guard !ports.isEmpty, !Task.isCancelled else { return .allFailed }
 
         return await withTaskGroup(of: PortProbeOutcome.self, returning: ProbeGroupResult.self) { group in
             var pending = 0
@@ -171,6 +181,10 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             }
 
             while pending > 0 {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    return .allFailed
+                }
                 guard let result = await group.next() else { break }
                 pending -= 1
 
@@ -202,7 +216,8 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
     }
 
     private static func probePort(ip: String, port: UInt16, timeout: Duration) async -> PortProbeOutcome {
-        await ConnectionBudget.shared.acquire()
+        guard !Task.isCancelled else { return .failed }
+        guard await ConnectionBudget.shared.acquire() else { return .failed }
 
         let host = NWEndpoint.Host(ip)
         let endpoint = NWEndpoint.hostPort(host: host, port: NWEndpoint.Port(rawValue: port)!)
@@ -253,6 +268,7 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             var iterator = ips.makeIterator()
 
             while pending < concurrencyLimit, let ip = iterator.next() {
+                guard !Task.isCancelled else { break }
                 pending += 1
                 group.addTask {
                     let timeoutMs = await tracker.adaptiveTimeout(base: 500)
@@ -265,6 +281,10 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
             }
 
             while let (ip, latency) = await group.next() {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
                 pending -= 1
                 if let latency {
                     await accumulator.updateLatency(ip: ip, latency: latency)
@@ -297,7 +317,8 @@ public struct TCPProbeScanPhase: ScanPhase, Sendable {
     /// Multi-port TCP connect for latency measurement — tries common ports concurrently,
     /// returns as soon as any responds.
     private static func quickLatencyProbe(ip: String, timeout: Duration) async -> Double? {
-        await ConnectionBudget.shared.acquire()
+        guard !Task.isCancelled else { return nil }
+        guard await ConnectionBudget.shared.acquire() else { return nil }
 
         let host = NWEndpoint.Host(ip)
 

--- a/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanEngine.swift
+++ b/Packages/NetworkScanKit/Sources/NetworkScanKit/ScanEngine.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+private actor ScanTimeoutRace {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isResolved = false
+
+    func wait() async {
+        guard !isResolved else { return }
+        await withCheckedContinuation { continuation in
+            guard !isResolved else {
+                continuation.resume()
+                return
+            }
+            self.continuation = continuation
+        }
+    }
+
+    func resolve() {
+        guard !isResolved else { return }
+        isResolved = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 /// Orchestrates scan phases according to a ``ScanPipeline``, tracking overall
 /// progress and accumulating discovered devices.
 public actor ScanEngine {
@@ -7,13 +30,12 @@ public actor ScanEngine {
     /// Declared `nonisolated` so callers can reference it without awaiting the actor.
     nonisolated public let accumulator: ScanAccumulator
 
-    public init() {
-        self.accumulator = ScanAccumulator()
-    }
+    private let phaseTimeout: Duration
 
-    /// Maximum time any single phase is allowed to run before being cancelled.
-    /// Prevents a broken NWConnection / NECP state from hanging the entire pipeline.
-    private static let phaseTimeout: Duration = .seconds(30)
+    public init(phaseTimeout: Duration = .seconds(30)) {
+        self.accumulator = ScanAccumulator()
+        self.phaseTimeout = phaseTimeout
+    }
 
     /// Run a complete scan using the given pipeline and context.
     ///
@@ -27,24 +49,28 @@ public actor ScanEngine {
         context: ScanContext,
         onProgress: @escaping @Sendable (Double, String) async -> Void
     ) async -> [DiscoveredDevice] {
+        guard !Task.isCancelled else { return await accumulator.sortedSnapshot() }
         let totalWeight = pipeline.steps.flatMap(\.phases).reduce(0.0) { $0 + $1.weight }
         guard totalWeight > 0 else { return await accumulator.sortedSnapshot() }
 
         var completedWeight: Double = 0
 
         for step in pipeline.steps {
+            guard !Task.isCancelled else { break }
             let baseWeight = completedWeight
 
             if step.concurrent && step.phases.count > 1 {
                 let accum = accumulator
-                let timeout = Self.phaseTimeout
+                let timeout = phaseTimeout
                 await withTaskGroup(of: Void.self) { group in
                     for phase in step.phases {
+                        guard !Task.isCancelled else { break }
                         let tw = totalWeight
                         let bw = baseWeight
                         group.addTask {
                             await Self.withTimeout(timeout) {
                                 await phase.execute(context: context, accumulator: accum) { phaseProgress in
+                                    guard !Task.isCancelled else { return }
                                     let overall = (bw + phase.weight * phaseProgress) / tw
                                     await onProgress(overall, phase.displayName)
                                 }
@@ -52,19 +78,23 @@ public actor ScanEngine {
                         }
                     }
                 }
+                guard !Task.isCancelled else { break }
                 completedWeight = baseWeight + step.phases.reduce(0.0) { $0 + $1.weight }
             } else {
                 for phase in step.phases {
+                    guard !Task.isCancelled else { break }
                     let phaseBase = completedWeight
                     let tw = totalWeight
-                    let timeout = Self.phaseTimeout
+                    let timeout = phaseTimeout
                     let accum = self.accumulator
                     await Self.withTimeout(timeout) {
                         await phase.execute(context: context, accumulator: accum) { phaseProgress in
+                            guard !Task.isCancelled else { return }
                             let overall = (phaseBase + phase.weight * phaseProgress) / tw
                             await onProgress(overall, phase.displayName)
                         }
                     }
+                    guard !Task.isCancelled else { break }
                     completedWeight += phase.weight
                 }
             }
@@ -101,18 +131,30 @@ public actor ScanEngine {
     /// Run an async operation with a timeout. If the operation exceeds the
     /// timeout, its task is cancelled and we move on.
     private static func withTimeout(_ duration: Duration, operation: @escaping @Sendable () async -> Void) async {
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                await operation()
-            }
-            group.addTask {
-                try? await Task.sleep(for: duration)
-            }
-            // When the first task completes (either operation finishes or timeout fires),
-            // cancel the remaining one and return.
-            await group.next()
-            group.cancelAll()
+        let race = ScanTimeoutRace()
+        let operationTask = Task {
+            await operation()
+            await race.resolve()
         }
+        let timeoutTask = Task {
+            do {
+                try await Task.sleep(for: duration)
+                await race.resolve()
+            } catch {
+                return
+            }
+        }
+
+        await withTaskCancellationHandler {
+            await race.wait()
+        } onCancel: {
+            operationTask.cancel()
+            timeoutTask.cancel()
+            Task { await race.resolve() }
+        }
+
+        operationTask.cancel()
+        timeoutTask.cancel()
     }
 
     /// Reset the accumulator for a fresh scan.

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ConnectionBudgetTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ConnectionBudgetTests.swift
@@ -58,15 +58,37 @@ struct ConnectionBudgetTests {
             await budget.acquire()
         }
 
-        // Give the pending task time to enqueue as a waiter
-        try await Task.sleep(nanoseconds: 20_000_000)  // 20ms
+        while await budget.waitingCount == 0 {
+            await Task.yield()
+        }
 
         await budget.reset()
-        // After reset, the waiter should be resumed and the task completes
-        await pending.value
+        let acquired = await pending.value
 
-        // After reset sets active=0, waiter does active+=1 → 1
+        #expect(!acquired)
+        #expect(await budget.activeCount == 0)
+    }
+
+    @Test("cancelling a waiter does not consume a connection slot")
+    func cancellationRemovesWaiter() async {
+        let budget = ConnectionBudget(limit: 1)
+        #expect(await budget.acquire())
+
+        let pending = Task {
+            await budget.acquire()
+        }
+        while await budget.waitingCount == 0 {
+            await Task.yield()
+        }
+
+        pending.cancel()
+
+        #expect(await pending.value == false)
+        #expect(await budget.waitingCount == 0)
         #expect(await budget.activeCount == 1)
+
+        await budget.release()
+        #expect(await budget.activeCount == 0)
     }
 
     @Test("acquire and release at limit boundary")
@@ -81,7 +103,7 @@ struct ConnectionBudgetTests {
         let task = Task {
             await budget.acquire()
         }
-        await task.value
+        #expect(await task.value)
         #expect(await budget.activeCount == 3)
     }
 

--- a/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanEngineTests.swift
+++ b/Packages/NetworkScanKit/Tests/NetworkScanKitTests/ScanEngineTests.swift
@@ -128,6 +128,44 @@ struct ScanEngineTests {
         #expect(await engine.accumulator.isEmpty)
     }
 
+    @Test("cancelling a scan prevents subsequent phases from starting")
+    func cancellationStopsPipeline() async {
+        let engine = ScanEngine()
+        let recorder = PhaseExecutionRecorder()
+        let pipeline = ScanPipeline(steps: [
+            ScanPipeline.Step(phases: [CancellableFixturePhase(id: "blocking", recorder: recorder, waitsForCancellation: true)], concurrent: false),
+            ScanPipeline.Step(phases: [CancellableFixturePhase(id: "should-not-run", recorder: recorder, waitsForCancellation: false)], concurrent: false)
+        ])
+
+        let scanTask = Task {
+            await engine.scan(pipeline: pipeline, context: makeContext(hosts: [])) { _, _ in }
+        }
+
+        while await !(recorder.hasExecuted("blocking")) {
+            await Task.yield()
+        }
+        scanTask.cancel()
+        _ = await scanTask.value
+
+        #expect(await recorder.hasExecuted("blocking"))
+        #expect(await !(recorder.hasExecuted("should-not-run")))
+    }
+
+    @Test("non-cooperative phase cannot hold the public scan past its deadline")
+    func nonCooperativePhaseTimesOut() async {
+        let engine = ScanEngine(phaseTimeout: .milliseconds(10))
+        let phase = NonCooperativeFixturePhase()
+        let pipeline = ScanPipeline(steps: [
+            ScanPipeline.Step(phases: [phase], concurrent: false)
+        ])
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        _ = await engine.scan(pipeline: pipeline, context: makeContext(hosts: [])) { _, _ in }
+
+        #expect(clock.now - start < .milliseconds(100))
+    }
+
     private func makeContext(hosts: [String]) -> ScanContext {
         ScanContext(
             hosts: hosts,
@@ -146,6 +184,55 @@ struct ScanEngineTests {
             discoveredAt: Date(),
             source: .local
         )
+    }
+}
+
+private struct CancellableFixturePhase: ScanPhase {
+    let id: String
+    let recorder: PhaseExecutionRecorder
+    let waitsForCancellation: Bool
+    let displayName = "Cancellation Fixture"
+    let weight = 1.0
+
+    func execute(
+        context _: ScanContext,
+        accumulator _: ScanAccumulator,
+        onProgress _: @Sendable (Double) async -> Void
+    ) async {
+        await recorder.record(id)
+        guard waitsForCancellation else { return }
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+    }
+}
+
+private actor PhaseExecutionRecorder {
+    private var executed: Set<String> = []
+
+    func record(_ id: String) {
+        executed.insert(id)
+    }
+
+    func hasExecuted(_ id: String) -> Bool {
+        executed.contains(id)
+    }
+}
+
+private struct NonCooperativeFixturePhase: ScanPhase {
+    let id = "non-cooperative"
+    let displayName = "Non-cooperative"
+    let weight = 1.0
+
+    func execute(
+        context _: ScanContext,
+        accumulator _: ScanAccumulator,
+        onProgress _: @Sendable (Double) async -> Void
+    ) async {
+        let deadline = ContinuousClock.now + .milliseconds(200)
+        while ContinuousClock.now < deadline {
+            await Task.yield()
+        }
     }
 }
 

--- a/Tests/NetMonitor-iOSTests/BackgroundTaskServiceExtendedTests.swift
+++ b/Tests/NetMonitor-iOSTests/BackgroundTaskServiceExtendedTests.swift
@@ -1,5 +1,6 @@
-import Testing
+import BackgroundTasks
 import Foundation
+import Testing
 @testable import NetMonitor_iOS
 
 // MARK: - BackgroundTaskService Extended Tests
@@ -21,8 +22,12 @@ struct BackgroundTaskServiceExtendedTests {
         let key = AppSettings.Keys.backgroundRefreshEnabled
         let original = defaults.object(forKey: key)
         defer {
-            if let original { defaults.set(original, forKey: key) }
-            else { defaults.removeObject(forKey: key) }
+            if let original {
+                defaults.set(original, forKey: key)
+            }
+            else {
+                defaults.removeObject(forKey: key)
+            }
         }
         defaults.set(false, forKey: key)
         let service = BackgroundTaskService.shared
@@ -36,8 +41,12 @@ struct BackgroundTaskServiceExtendedTests {
         let key = AppSettings.Keys.backgroundRefreshEnabled
         let original = defaults.object(forKey: key)
         defer {
-            if let original { defaults.set(original, forKey: key) }
-            else { defaults.removeObject(forKey: key) }
+            if let original {
+                defaults.set(original, forKey: key)
+            }
+            else {
+                defaults.removeObject(forKey: key)
+            }
         }
         defaults.set(true, forKey: key)
         let service = BackgroundTaskService.shared
@@ -51,8 +60,12 @@ struct BackgroundTaskServiceExtendedTests {
         let key = AppSettings.Keys.backgroundRefreshEnabled
         let original = defaults.object(forKey: key)
         defer {
-            if let original { defaults.set(original, forKey: key) }
-            else { defaults.removeObject(forKey: key) }
+            if let original {
+                defaults.set(original, forKey: key)
+            }
+            else {
+                defaults.removeObject(forKey: key)
+            }
         }
         defaults.removeObject(forKey: key)
         let service = BackgroundTaskService.shared
@@ -88,10 +101,21 @@ struct BackgroundTaskServiceExtendedTests {
         }
     }
 
-    @Test("registerTasks does not crash in test sandbox")
-    func registerTasksDoesNotCrash() {
-        // BGTaskScheduler.shared.register() in test sandbox may warn but must not crash
-        let service = BackgroundTaskService.shared
+    @Test("registerTasks registers every identifier exactly once")
+    func registerTasksIsIdempotent() {
+        var registeredIdentifiers: [String] = []
+        let service = BackgroundTaskService { identifier, _, _ in
+            registeredIdentifiers.append(identifier)
+            return true
+        }
+
         service.registerTasks()
+        service.registerTasks()
+
+        #expect(registeredIdentifiers == [
+            BackgroundTaskService.refreshTaskIdentifier,
+            BackgroundTaskService.syncTaskIdentifier,
+            BackgroundTaskService.scheduledNetworkScanTaskIdentifier
+        ])
     }
 }

--- a/Tests/NetMonitor-iOSTests/EventListenerServiceTests.swift
+++ b/Tests/NetMonitor-iOSTests/EventListenerServiceTests.swift
@@ -101,6 +101,20 @@ struct EventListenerServiceTests {
         // No crash or double-fire
     }
 
+    @Test("cancellation resumes a suspended observation wait")
+    func cancellationResumesObservationWait() async {
+        let waiter = ObservationChangeWaiter()
+        let task = Task {
+            await waiter.wait { _ in }
+        }
+
+        await Task.yield()
+        task.cancel()
+        await task.value
+
+        #expect(task.isCancelled)
+    }
+
     // MARK: - SpyNetworkEventService validation
 
     @Test("SpyNetworkEventService captures logged events correctly")

--- a/Tests/NetMonitor-iOSTests/MacConnectionServiceReceiveBufferTests.swift
+++ b/Tests/NetMonitor-iOSTests/MacConnectionServiceReceiveBufferTests.swift
@@ -7,7 +7,7 @@ import NetMonitorCore
 struct MacConnectionServiceReceiveBufferTests {
 
     @Test("processReceiveBuffer handles back-to-back frames after buffer advances")
-    func processReceiveBufferHandlesBackToBackFrames() throws {
+    func processReceiveBufferHandlesBackToBackFrames() async throws {
         let service = MacConnectionService.shared
         service.disconnect()
 
@@ -29,7 +29,7 @@ struct MacConnectionServiceReceiveBufferTests {
         var combined = firstFrame
         combined.append(secondFrame)
 
-        service.processIncomingDataForTesting(combined)
+        await service.processIncomingDataForTesting(combined)
 
         #expect(service.lastStatusUpdate?.onlineTargets == 2)
         #expect(service.lastStatusUpdate?.offlineTargets == 1)

--- a/Tests/NetMonitor-iOSTests/MacConnectionServiceTests.swift
+++ b/Tests/NetMonitor-iOSTests/MacConnectionServiceTests.swift
@@ -128,7 +128,7 @@ struct MacConnectionServiceTests {
     // MARK: - processIncomingDataForTesting
 
     @Test("processIncomingDataForTesting handles single statusUpdate frame")
-    func processIncomingSingleFrame() throws {
+    func processIncomingSingleFrame() async throws {
         let service = MacConnectionService.shared
         service.disconnect()
 
@@ -139,7 +139,7 @@ struct MacConnectionServiceTests {
             averageLatency: 25.0
         ))
         let data = try message.encodeLengthPrefixed()
-        service.processIncomingDataForTesting(data)
+        await service.processIncomingDataForTesting(data)
 
         #expect(service.lastStatusUpdate?.onlineTargets == 10)
         #expect(service.lastStatusUpdate?.offlineTargets == 3)
@@ -147,30 +147,30 @@ struct MacConnectionServiceTests {
     }
 
     @Test("processIncomingDataForTesting ignores incomplete frames")
-    func processIncomingIncompleteFrame() {
+    func processIncomingIncompleteFrame() async {
         let service = MacConnectionService.shared
         service.disconnect()
 
         // Send only 2 bytes (less than the 4-byte length prefix)
-        service.processIncomingDataForTesting(Data([0x00, 0x00]))
+        await service.processIncomingDataForTesting(Data([0x00, 0x00]))
         #expect(service.lastStatusUpdate == nil)
     }
 
     @Test("processIncomingDataForTesting rejects absurdly large frame length")
-    func processIncomingAbsurdFrameLength() {
+    func processIncomingAbsurdFrameLength() async {
         let service = MacConnectionService.shared
         service.disconnect()
 
         // Frame length of 0xFF_FF_FF_FF (>10MB limit)
         var data = Data([0xFF, 0xFF, 0xFF, 0xFF])
         data.append(Data(repeating: 0x00, count: 100))
-        service.processIncomingDataForTesting(data)
+        await service.processIncomingDataForTesting(data)
 
         #expect(service.lastStatusUpdate == nil)
     }
 
     @Test("processIncomingDataForTesting handles deviceList message")
-    func processIncomingDeviceList() throws {
+    func processIncomingDeviceList() async throws {
         let service = MacConnectionService.shared
         service.disconnect()
 
@@ -186,10 +186,23 @@ struct MacConnectionServiceTests {
         let message = CompanionMessage.deviceList(payload)
         let data = try message.encodeLengthPrefixed()
 
-        service.processIncomingDataForTesting(data)
+        await service.processIncomingDataForTesting(data)
 
         #expect(service.lastDeviceList?.devices.count == 1)
         #expect(service.lastDeviceList?.devices.first?.ipAddress == "192.168.1.100")
         #expect(service.lastDeviceList?.devices.first?.hostname == "test-host")
+    }
+
+    @Test("reconnect policy uses capped exponential backoff")
+    func reconnectBackoffPolicy() {
+        let first = MacConnectionService.reconnectDelay(attempt: 1, jitterFraction: 0)
+        let second = MacConnectionService.reconnectDelay(attempt: 2, jitterFraction: 0)
+        let jittered = MacConnectionService.reconnectDelay(attempt: 3, jitterFraction: 1)
+        let capped = MacConnectionService.reconnectDelay(attempt: 20, jitterFraction: 1)
+
+        #expect(first == 1)
+        #expect(second == 2)
+        #expect(jittered == 5)
+        #expect(capped == 60)
     }
 }

--- a/Tests/NetMonitor-macOSTests/AppearanceModeTests.swift
+++ b/Tests/NetMonitor-macOSTests/AppearanceModeTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import NetMonitorCore
+import SwiftData
 import Testing
 @testable import NetMonitor_macOS
 
@@ -35,5 +37,44 @@ struct AppearanceModeTests {
     @Test func iconNamesAreDistinct() {
         let icons = Set(AppearanceMode.allCases.map(\.iconName))
         #expect(icons.count == AppearanceMode.allCases.count)
+    }
+
+    @Test("v2.2.0 macOS SchemaV1 store reopens through the migration plan")
+    @MainActor
+    func lastShippedStoreReopens() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "netmonitor-mac-v220-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let storeURL = directory.appending(path: "v2.2.0.store")
+        let schema = Schema(versionedSchema: SchemaV1.self)
+        let fixtureID = UUID()
+
+        do {
+            let configuration = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: NetMonitorMigrationPlan.self,
+                configurations: [configuration]
+            )
+            container.mainContext.insert(NetworkTarget(
+                id: fixtureID,
+                name: "v2.2.0 fixture",
+                host: "fixture.invalid",
+                targetProtocol: .icmp
+            ))
+            try container.mainContext.save()
+        }
+
+        let configuration = ModelConfiguration(schema: schema, url: storeURL, cloudKitDatabase: .none)
+        let reopened = try ModelContainer(
+            for: schema,
+            migrationPlan: NetMonitorMigrationPlan.self,
+            configurations: [configuration]
+        )
+        let targets = try reopened.mainContext.fetch(FetchDescriptor<NetworkTarget>())
+
+        #expect(targets.map(\.id).contains(fixtureID))
     }
 }

--- a/Tests/NetMonitor-macOSTests/DeviceDiscoveryCoordinatorTests.swift
+++ b/Tests/NetMonitor-macOSTests/DeviceDiscoveryCoordinatorTests.swift
@@ -48,6 +48,36 @@ struct DeviceDiscoveryCoordinatorTests {
         #expect(inserted?.hostname == "camera.local")
     }
 
+    @Test func mergeDiscoveredDevicesToleratesDuplicateHistoricalIdentifiers() throws {
+        let (container, context) = try makeInMemoryStore()
+        _ = container
+
+        context.insert(LocalDevice(
+            ipAddress: "192.168.1.10",
+            macAddress: "AA:BB:CC:DD:EE:FF",
+            hostname: "old-one.local"
+        ))
+        context.insert(LocalDevice(
+            ipAddress: "192.168.1.11",
+            macAddress: "AA:BB:CC:DD:EE:FF",
+            hostname: "old-two.local"
+        ))
+        try context.save()
+
+        let coordinator = makeCoordinator(context: context)
+        coordinator.mergeDiscoveredDevices([
+            LocalDiscoveredDevice(
+                ipAddress: "192.168.1.12",
+                macAddress: "aa:bb:cc:dd:ee:ff",
+                hostname: "current.local"
+            )
+        ], profileID: nil)
+
+        let devices = try context.fetch(FetchDescriptor<LocalDevice>())
+        #expect(devices.count == 2)
+        #expect(devices.contains { $0.hostname == "current.local" && $0.ipAddress == "192.168.1.12" })
+    }
+
     @Test func markOfflineDevicesMarksOnlyMissingIPsOffline() throws {
         let (container, context) = try makeInMemoryStore()
         _ = container


### PR DESCRIPTION
## Summary

Implements the v2.2.1 Reliability and Responsiveness release proposal tracked in #262.

- Makes iOS background registration idempotent and cancellation-safe.
- Adds cancellation-aware connection budgeting, phase deadlines, NWConnection cancellation, and background scan expiration handling.
- Replaces silent in-memory persistence fallback with explicit recovery UI and diagnostic export on iOS and macOS.
- Adds store compatibility, persistence recovery, framing, coalescing, timeout, and cancellation regressions.
- Coalesces scan progress to 10 Hz, batches macOS device merging, and bounds high-volume UI queries.
- Hardens companion framing, stale callbacks, terminal cleanup, and exponential reconnect backoff.
- Improves dashboard scan/empty/offline states and identifiers on release-critical paths.

## Verification

- NetMonitorCore: 1,358 tests passed.
- NetworkScanKit: 317 tests passed.
- macOS Debug build passed.
- iOS Simulator Debug build passed.
- macOS and iOS unit/UI test bundles build-for-testing passed.
- SwiftLint passed.
- All 44 changed Swift files pass SwiftFormat.
- Periphery completed successfully with warning-only existing findings.
- jscpd completed below its configured failure threshold.
- Modern legacy-pattern audit found zero app-target errors.
- New persistence recovery screens pass the accessibility audit.

## Release-candidate blockers

- Full macOS/iOS app test execution must run on mac-mini per project policy. SSH to 100.87.12.30:22 currently times out.
- Archive/signing, TestFlight, and manual VoiceOver/keyboard smoke tests remain release operations.
- Repository-wide accessibility and formatter baseline debt are tracked in #263 and #264.

Tracks #262.